### PR TITLE
Try another img that shows on the ipynb file

### DIFF
--- a/tutorials/01_simplicial_complexes.ipynb
+++ b/tutorials/01_simplicial_complexes.ipynb
@@ -28,11 +28,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "c9a65d5a-0e1a-4405-a913-a6c2a28cb206",
-   "metadata": {
-    "tags": [
-     "nbsphinx-thumbnail"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -72,7 +68,11 @@
    },
    "cell_type": "markdown",
    "id": "7dd06ad0",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "source": [
     "![simplexes-2.png](attachment:simplexes-2.png)"
    ]


### PR DESCRIPTION
The  notebook's .html page looks great, with all images showing.
Only the thumbnail does not show.
It also does not show on the .ipynb.
Thus we try using an image that shows on the .ipynb as thumbnail.
