### PR TITLE
Restrict dependency HyperNetX to < 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies=[
     "gudhi",
     "decorator",
     "networkx",
-    "hypernetx",
+    "hypernetx < 2.0.0",
     "numpy",
     "scipy",
     "trimesh",


### PR DESCRIPTION
HyperNetX 2.0.0.post1 introduced breaking changes compared to 1.2.5. See also #38.