### PR TITLE
Add protein-protein-interaction dataset loading in nx.Graph format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies=[
     "networkx",
     "hypernetx < 2.0.0",
     "numpy",
+    "requests",
     "scipy",
     "trimesh",
 ]

--- a/test/datasets/test_utils.py
+++ b/test/datasets/test_utils.py
@@ -1,0 +1,15 @@
+"""Test utils loading datasets."""
+
+import unittest
+
+import toponetx.datasets.utils as data_utils
+
+
+class TestUtils(unittest.TestCase):
+    """Test datasets utils."""
+
+    def test_load_ppi(self):
+        """Test that the ppi dataset loads correctly."""
+        G = data_utils.load_ppi()
+        assert len(G.nodes) == 20
+        assert len(G.edges) == 102

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -764,11 +764,13 @@ class SimplicialComplex(Complex):
             return
 
     def get_node_attributes(self, name):
-        """Get node attributes from combintorial complex
+        """Get node attributes from combinatorial complex.
+
         Parameters
         ----------
         name : string
-           Attribute name
+           Attribute name.
+
         Returns
         -------
         Dictionary of attributes keyed by node.

--- a/toponetx/datasets/utils.py
+++ b/toponetx/datasets/utils.py
@@ -1,10 +1,4 @@
-"""Loading toy datasets.
-
-Refer to notebook: `geomstats/notebooks/01_data_on_manifolds.ipynb`
-to visualize these datasets.
-
-Lead author: Nina Miolane.
-"""
+"""Utils to load datasets."""
 
 import networkx as nx
 import numpy as np

--- a/toponetx/datasets/utils.py
+++ b/toponetx/datasets/utils.py
@@ -1,4 +1,4 @@
-"""Utils to load datasets."""
+"""Utils loading datasets."""
 
 import networkx as nx
 import numpy as np
@@ -55,7 +55,7 @@ def load_ppi():
     data = [line.split("\t") for line in lines]
     df = pd.DataFrame(data[1:-1], columns=data[0])
 
-    interactions = df[["protein_a", "protein_b", "score"]]
+    interactions = df[["preferredName_A", "preferredName_B", "score"]]
 
     G = nx.Graph(name="Protein Interaction Graph")
     interactions = np.array(interactions)

--- a/toponetx/datasets/utils.py
+++ b/toponetx/datasets/utils.py
@@ -1,0 +1,73 @@
+"""Loading toy datasets.
+
+Refer to notebook: `geomstats/notebooks/01_data_on_manifolds.ipynb`
+to visualize these datasets.
+
+Lead author: Nina Miolane.
+"""
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import requests
+
+
+def load_ppi():
+    """Load the protein-protein-interaction graph.
+
+    In the graph, high interaction score is represented as low weight.
+
+    Reference
+    ---------
+    https://towardsdatascience.com/visualizing-protein-networks-in-python-58a9b51be9d5
+
+    Returns
+    -------
+    _ : networkx.Graph
+        Graph with nodes that are proteins and edges corresponding to their
+        chemical interactions.
+    """
+    protein_list = [
+        "TPH1",
+        "COMT",
+        "SLC18A2",
+        "HTR1B",
+        "HTR2C",
+        "HTR2A",
+        "MAOA",
+        "TPH2",
+        "HTR1A",
+        "HTR7",
+        "SLC6A4",
+        "GABBR2",
+        "POMC",
+        "GNAI3",
+        "NPY",
+        "ADCY1",
+        "PDYN",
+        "GRM2",
+        "GRM3",
+        "GABBR1",
+    ]
+    proteins = "%0d".join(protein_list)
+    url = (
+        "https://string-db.org/api/tsv/network?identifiers="
+        + proteins
+        + "&species=9606"
+    )
+    r = requests.get(url)
+
+    lines = r.text.split("\n")
+    data = [line.split("\t") for line in lines]
+    df = pd.DataFrame(data[1:-1], columns=data[0])
+
+    interactions = df[["protein_a", "protein_b", "score"]]
+
+    G = nx.Graph(name="Protein Interaction Graph")
+    interactions = np.array(interactions)
+    for interaction in interactions:
+        protein_a = interaction[0]
+        protein_b = interaction[1]
+        interaction_weight = float(interaction[2])
+        G.add_weighted_edges_from([(protein_a, protein_b, interaction_weight)])
+    return G


### PR DESCRIPTION
This PR adds a `datasets` folder where standard datasets on topological domains can be added. the `utils.py` module allows users to load each dataset through a single point of entry, like a `load_*()` function.

To exemplify this, this PR adds the PPI (protein-protein-interaction) dataset.

While the PPI dataset is loaded in networkx graph format, the functionalities in `transform/` can be used to lift that graph into another topological domain.