### PR TITLE
Fix CellComplex incidence matrix and test case

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -162,10 +162,18 @@ class TestCellComplex(unittest.TestCase):
         """Test the shape of the incidence matrix for the cell complex."""
         CX = CellComplex()
         CX.add_cells_from([[1, 2, 3, 4], [2, 3, 4, 5], [5, 6, 7, 8]], rank=2)
-        B = CX.incidence_matrix(2)
+        row_index, col_index, B = CX.incidence_matrix(2, index=True)
         assert B.shape == (10, 3)
-        B = CX.incidence_matrix(1)
+        assert len(row_index) == 10
+        assert len(col_index) == 3
+        row_index, col_index, B = CX.incidence_matrix(1, index=True)
         assert B.shape == (8, 10)
+        assert len(row_index) == 8
+        assert len(col_index) == 10
+        row_index, col_index, B = CX.incidence_matrix(0, index=True)
+        assert B.shape == (0, 8)
+        assert len(row_index) == 0
+        assert len(col_index) == 8
 
     def test_incidence_matrix_empty_cell_complex(self):
         """Test the incidence matrix for an empty cell complex."""

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -1325,15 +1325,13 @@ class CellComplex(Complex):
         import scipy.sparse
 
         if rank == 0:
-            A = sp.sparse.lil_matrix((1, len(self._G.nodes)))
-            for i in range(0, len(self._G.nodes)):
-                A[0, i] = 1
+            A = sp.sparse.lil_matrix((0, len(self._G.nodes)))
             if index:
                 node_index = {node: i for i, node in enumerate(sorted(self._G.nodes))}
                 if signed:
-                    return node_index, [], A.asformat("csc")
+                    return {}, node_index, A.asformat("csc")
                 else:
-                    return node_index, [], abs(A.asformat("csc"))
+                    return {}, node_index, abs(A.asformat("csc"))
             else:
                 if signed:
                     return A.asformat("csc")


### PR DESCRIPTION
From #40:

>`CellComplex.incidence_matrix()` for nodes returns a $1\times n$ matrix instead of $0\times n$ (seems incorrect, but maybe something depends on this behavior?)
> - with `index=True`, it returns an empty row index list, but matrix has one row.
> - with `index=True` it also returns the indices in the wrong (inconsistent with higher ranks) order