### PR TITLE
Add missing calls to constructors of superclass

### DIFF
--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -124,6 +124,8 @@ class CellComplex(Complex):
     """
 
     def __init__(self, cells=None, name=None, regular=True, **attr):
+        super().__init__()
+
         if not name:
             self.name = ""
         else:

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -86,6 +86,8 @@ class CombinatorialComplex(Complex):
     def __init__(
         self, cells=None, name=None, ranks=None, weight=None, graph_based=False, **attr
     ):
+        super().__init__()
+
         if not name:
             self.name = ""
         else:

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -103,6 +103,7 @@ class SimplicialComplex(Complex):
     """
 
     def __init__(self, simplices=None, name=None, mode="normal", **attr):
+        super().__init__()
 
         self.mode = mode
         if name is None:


### PR DESCRIPTION
Even though the constructor of the superclass is currently empty, it is generally a good idea to always call it anyway. This avoids issues down the line if eventually something is added to the superclass.