### PR TITLE
Cleanup imports from `collections.abc`

### DIFF
--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -1,10 +1,7 @@
 """Cell and CellView classes."""
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
 from collections import Counter, deque
+from collections.abc import Iterable
 from itertools import zip_longest
 
 import numpy as np

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -8,13 +8,8 @@ We reserve the notation CC for a combinatorial complex.
 """
 
 import warnings
-
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Iterable, Hashable
-
 from collections import defaultdict
+from collections.abc import Hashable, Iterable
 from itertools import zip_longest
 
 import networkx as nx

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -1,12 +1,7 @@
 """Creation and manipulation of a combinatorial complex."""
 
 import warnings
-
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Iterable
-    from collections import Hashable
+from collections.abc import Hashable, Iterable
 
 import networkx as nx
 import numpy as np

--- a/toponetx/classes/hyperedge.py
+++ b/toponetx/classes/hyperedge.py
@@ -1,11 +1,7 @@
 """HyperEdge classes."""
 
 
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Hashable, Iterable
-
+from collections.abc import Hashable, Iterable
 
 __all__ = ["HyperEdge"]
 

--- a/toponetx/classes/node.py
+++ b/toponetx/classes/node.py
@@ -1,9 +1,6 @@
 """NodeView class."""
 
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Hashable, Iterable
+from collections.abc import Hashable, Iterable
 
 from toponetx import TopoNetXError
 

--- a/toponetx/classes/reportview.py
+++ b/toponetx/classes/reportview.py
@@ -3,14 +3,9 @@
 Such as:
 HyperEdgeView, CellView, SimplexView.
 """
+from collections.abc import Hashable, Iterable
 
 import numpy as np
-
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Iterable, Hashable
-
 
 from toponetx import TopoNetXError
 from toponetx.classes.cell import Cell

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -1,9 +1,6 @@
 """Simplex Class."""
 
-try:
-    from collections.abc import Hashable, Iterable
-except ImportError:
-    from collections import Iterable, Hashable
+from collections.abc import Hashable, Iterable
 from itertools import combinations
 
 __all__ = ["Simplex"]


### PR DESCRIPTION
The `collections.abc` module is available since Python 3.3. As the minimum required Python version for TopoNetX is 3.9, the fallback is unnecessary.