### PR TITLE
Fix errors discovered by mypy

### DIFF
--- a/test/utils/test_structure.py
+++ b/test/utils/test_structure.py
@@ -84,16 +84,18 @@ class TestStructure(unittest.TestCase):
             list, {0: [0, 1], 1: [0, 2], 2: [1, 2], 3: [3, 4], 4: [3, 5], 5: [4, 5]}
         )
         assert out == d
-    
+
     def test_neighborhood_list_to_neighborhood_with_dict(self):
         """Test that neighborhood_list_to_neighborhood_dict works correctly with specified node dictionary."""
-        node_dict = { 1: 'a', 2: 'b', 3: 'c'}
-        neigh_list = [(1,2), (2,1), (2,3), (3,2)]
-        neigh_dict = neighborhood_list_to_neighborhood_dict(neigh_list, node_dict, node_dict)
+        node_dict = {1: "a", 2: "b", 3: "c"}
+        neigh_list = [(1, 2), (2, 1), (2, 3), (3, 2)]
+        neigh_dict = neighborhood_list_to_neighborhood_dict(
+            neigh_list, node_dict, node_dict
+        )
         assert len(neigh_dict) == 3
-        assert neigh_dict['a'] == ['b']
-        assert set(neigh_dict['b']) == {'a', 'c'} # order irrelevant
-        assert neigh_dict['c'] == ['b']
+        assert neigh_dict["a"] == ["b"]
+        assert set(neigh_dict["b"]) == {"a", "c"}  # order irrelevant
+        assert neigh_dict["c"] == ["b"]
 
     def test_sparse_array_to_neighborhood_dict(self):
         """Test the sparse_array_to_neighborhood_dict function."""

--- a/test/utils/test_structure.py
+++ b/test/utils/test_structure.py
@@ -84,6 +84,16 @@ class TestStructure(unittest.TestCase):
             list, {0: [0, 1], 1: [0, 2], 2: [1, 2], 3: [3, 4], 4: [3, 5], 5: [4, 5]}
         )
         assert out == d
+    
+    def test_neighborhood_list_to_neighborhood_with_dict(self):
+        """Test that neighborhood_list_to_neighborhood_dict works correctly with specified node dictionary."""
+        node_dict = { 1: 'a', 2: 'b', 3: 'c'}
+        neigh_list = [(1,2), (2,1), (2,3), (3,2)]
+        neigh_dict = neighborhood_list_to_neighborhood_dict(neigh_list, node_dict, node_dict)
+        assert len(neigh_dict) == 3
+        assert neigh_dict['a'] == ['b']
+        assert set(neigh_dict['b']) == {'a', 'c'} # order irrelevant
+        assert neigh_dict['c'] == ['b']
 
     def test_sparse_array_to_neighborhood_dict(self):
         """Test the sparse_array_to_neighborhood_dict function."""

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -23,7 +23,7 @@ indices in S and T to other values.
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Iterable
 
 
 def sparse_array_to_neighborhood_list(
@@ -55,7 +55,7 @@ def sparse_array_to_neighborhood_list(
 
 
 def neighborhood_list_to_neighborhood_dict(
-    n_list: List[Tuple[int, int]], src_dict=None, dst_dict=None
+    n_list: Iterable[Tuple[int, int]], src_dict=None, dst_dict=None
 ) -> Dict[int, List[int]]:
     r"""Convert neighborhood list to neighborhood dictionary for arbitrary higher order structures.
 
@@ -67,8 +67,8 @@ def neighborhood_list_to_neighborhood_dict(
     ----------
         ``n_list`` (``List[Tuple[int, int]]``): neighborhood list.
     """
+    neighborhood_dict = defaultdict(list)
     if src_dict is None and dst_dict is None:
-        neighborhood_dict = defaultdict(list)
         for src_idx, dst_idx in n_list:
             neighborhood_dict[src_idx].append(dst_idx)
         return neighborhood_dict

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -23,7 +23,7 @@ indices in S and T to other values.
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple, Iterable
+from typing import Dict, Iterable, List, Tuple
 
 
 def sparse_array_to_neighborhood_list(


### PR DESCRIPTION
- typing > neighborhood_list_to_neighborhood_dict was called with iterable (in a different function), but list was specified -- since only an iterable was needed, I relaxed the type hint.
- same function used dictionary tried to use an undefined variable