### PR TITLE
[BREAKING CHANGES] Clean up attribute getter / setter for CellComplex

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -561,7 +561,7 @@ class TestCellComplex(unittest.TestCase):
             rank=2,
         )
         CX.add_cell([3, 4, 8], rank=2)
-        CX.set_cell_attributes(d)
+        CX.set_cell_attributes(d, rank=2)
         cell_color = CX.get_cell_attributes("color", 2)
         assert cell_color == {((1, 2, 3, 4), 0): "red", (1, 2, 4): "blue"}
 


### PR DESCRIPTION
Since the functionality was partially duplicated and having seperate methods for nodes, edges, and cells seemed to serve no purpose beyond confusing our users, I unified all functionality into get_cell_attributes and set_cell_attributes.

Of course, this breaks multiple things. If you prefer, I can make everything compatible with the old way it works, but this will only clutter up our code and set unexpected default values. If there are no or few users who's code we break, I would prefer the cleaner way.

- `set_cell_attributes` now requires rank (could set default to 2)
- `set_node_attributes`, `set_edge_attributes` and respective getters don't exist anymore (could re-add them to simply call the new methods)

I also replaced some code with calls to respective NetworkX functions as it did the same thing.