### PR TITLE
Cleanup docstrings

### DIFF
--- a/toponetx/algorithms/spectrum.py
+++ b/toponetx/algorithms/spectrum.py
@@ -182,7 +182,7 @@ def laplacian_spectrum(matrix, weight="weight"):
     ----------
     matrix : scipy sparse matrix
 
-    weight : string or None, optional (default='weight')
+    weight : str or None, optional (default='weight')
        If None, then each cell has weight 1.
 
     Returns
@@ -202,8 +202,7 @@ def cell_complex_hodge_laplacian_spectrum(CX: CellComplex, rank: int, weight="we
     Parameters
     ----------
     matrix : scipy sparse matrix
-
-    weight : string or None, optional (default='weight')
+    weight : str or None, optional (default='weight')
         If None, then each cell has weight 1.
 
     Returns
@@ -211,8 +210,8 @@ def cell_complex_hodge_laplacian_spectrum(CX: CellComplex, rank: int, weight="we
     evals : NumPy array
         Eigenvalues.
 
-    Example
-    -------
+    Examples
+    --------
     >>> CX = CellComplex()
     >>> CX.add_cell([1,2,3,4],rank=2)
     >>> CX.add_cell([2,3,4,5],rank=2)
@@ -230,8 +229,7 @@ def simplicial_complex_hodge_laplacian_spectrum(
     Parameters
     ----------
     matrix : scipy sparse matrix
-
-    weight : string or None, optional (default='weight')
+    weight : str or None, optional (default='weight')
         If None, then each cell has weight 1.
 
     Returns
@@ -239,7 +237,7 @@ def simplicial_complex_hodge_laplacian_spectrum(
     evals : NumPy array
         Eigenvalues.
 
-    Example
+    Examples
     --------
     >>> SC=SimplicialComplex([[1,2,3],[2,3,5],[0,1]])
     >>> spectrum=simplicial_complex_hodge_laplacian_spectrum(SC,1)
@@ -253,8 +251,7 @@ def cell_complex_adjacency_spectrum(CX: CellComplex, rank, weight="weight"):
     Parameters
     ----------
     matrix : scipy sparse matrix
-
-    weight : string or None, optional (default='weight')
+    weight : str or None, optional (default='weight')
        If None, then each cell has weight 1.
 
     Returns
@@ -262,8 +259,8 @@ def cell_complex_adjacency_spectrum(CX: CellComplex, rank, weight="weight"):
     evals : NumPy array
       Eigenvalues
 
-    Example
-    -------
+    Examples
+    --------
     >>> CX = CellComplex()
     >>> CX.add_cell([1,2,3,4],rank=2)
     >>> CX.add_cell([2,3,4,5],rank=2)
@@ -281,8 +278,7 @@ def simplicial_complex_adjacency_spectrum(
     Parameters
     ----------
     matrix : scipy sparse matrix
-
-    weight : string or None, optional (default='weight')
+    weight : str or None, optional (default='weight')
         If None, then each cell has weight 1.
 
     Returns
@@ -299,8 +295,7 @@ def combinatorial_complex_adjacency_spectrum(CC, r, k, weight="weight"):
     Parameters
     ----------
     matrix : scipy sparse matrix
-
-    weight : string or None, optional (default='weight')
+    weight : str or None, default='weight'
         If None, then each cell has weight 1.
 
     Returns
@@ -308,8 +303,8 @@ def combinatorial_complex_adjacency_spectrum(CC, r, k, weight="weight"):
     evals : NumPy array
         Eigenvalues
 
-    Example
-    -------
+    Examples
+    --------
     >>> CC = CombinatorialComplex(cells=[[1,2,3],[2,3], [0] ],ranks=[2,1,0] )
     >>> s = laplacian_spectrum( CC.adjacency_matrix( 0,2) )
     """

--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -13,7 +13,7 @@ __all__ = ["Cell"]
 
 
 class Cell:
-    r"""Class representing a 2D cell.
+    """Class representing a 2D cell.
 
     A 2D cell is an elementary building block used to build a 2D cell complex, whether regular or non-regular.
 
@@ -96,7 +96,7 @@ class Cell:
         self.properties.update(attr)
 
     def __getitem__(self, item):
-        r"""Retrieve the value associated with the given key in the properties dictionary.
+        """Retrieve the value associated with the given key in the properties dictionary.
 
         Parameters
         ----------
@@ -118,7 +118,7 @@ class Cell:
             return self.properties[item]
 
     def __setitem__(self, key, item):
-        r"""Set the value associated with the given key in the properties dictionary.
+        """Set the value associated with the given key in the properties dictionary.
 
         Parameters
         ----------
@@ -135,7 +135,7 @@ class Cell:
 
     @property
     def is_regular(self):
-        r"""Check if a cell is regular.
+        """Check if a cell is regular.
 
         Return true is the Cell is a regular cell, and False otherwise
         """
@@ -151,7 +151,7 @@ class Cell:
         return True
 
     def __len__(self):
-        r"""Get the number of elements in the cell.
+        """Get the number of elements in the cell.
 
         Returns
         -------
@@ -161,7 +161,7 @@ class Cell:
         return len(self._elements)
 
     def __iter__(self):
-        r"""Iterate over the elements in the cell.
+        """Iterate over the elements in the cell.
 
         Returns
         -------
@@ -171,7 +171,7 @@ class Cell:
         return iter(self._elements)
 
     def sign(self, edge):
-        r"""Compute the sign of the edge with respect to the cell.
+        """Compute the sign of the edge with respect to the cell.
 
         This takes an edge as input and computes the sign of the edge with respect to the cell.
 
@@ -218,7 +218,7 @@ class Cell:
 
     @property
     def boundary(self):
-        r"""Boundary.
+        """Boundary.
 
         A 2d cell is characterized by its boundary edges.
 
@@ -238,7 +238,7 @@ class Cell:
 
         Returns
         -------
-        _ : Cell
+        Cell
             New cell with the new reversed elements.
         """
         c = Cell(self._elements[::-1], name=self.name, regular=self._regular)
@@ -254,7 +254,7 @@ class Cell:
 
         Returns
         -------
-        _ : bool
+        bool
             Return True is self is homotopic to input cell and False otherwise.
         """
         return Cell._are_homotopic(self, cell) or Cell._are_homotopic(

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -71,13 +71,10 @@ class CellComplex(Complex):
         such as sparse matrices.
     5. Robust error handling and validation of input data, ensuring that the package is reliable and easy to use.
 
-    # Example 0
-    -----------
-    >>> # Cell Complex can be empty
-    >>> CX = CellComplex()
+    Examples
+    --------
+    Iteratively construct a cell complex:
 
-    # Example 1
-    -----------
     >>> CX = CellComplex()
     >>> CX.add_cell([1, 2, 3, 4], rank=2)
     >>> # the cell [1, 2, 3, 4] consists of the cycle (1,2), (2,3), (3,4), (4,5)
@@ -85,15 +82,14 @@ class CellComplex(Complex):
     >>> CX.add_cell([2, 3, 4, 5], rank=2)
     >>> CX.add_cell([5, 6, 7, 8], rank=2)
 
-    # Example 2
-    -----------
+    You can also pass a list of cells to the constructor:
+
     >>> c1 = Cell((1, 2, 3)) # a cell here is always assumed to be 2d
     >>> c2 = Cell((1, 2, 3, 4))
     >>> CX = CellComplex([c1, c2])
 
-    # Example 3
-    -----------
-    >>> compatibility with networkx
+    TopoNetX is also compatible with NetworkX, allowing users to create a cell complex from a NetworkX graph:
+
     >>> import networkx as nx
     >>> g = nx.Graph()
     >>> g.add_edge(1, 0)
@@ -103,8 +99,9 @@ class CellComplex(Complex):
     >>> CX.add_cells_from([[1, 2, 4], [1, 2, 7]], rank=2)
     >>> CX.cells
 
-    # Example 4
-    -----------
+    By default, a regular cell complex is constructed. You can change this behaviour using the
+    `regular` parameter when constructing the complex.
+
     >>> # non-regular cell complex
     >>> # by default CellComplex constructor assumes regular cell complex
     >>> CX = CellComplex(regular=False)
@@ -112,15 +109,8 @@ class CellComplex(Complex):
     >>> CX.add_cell([2, 3, 4, 5, 2, 3, 4, 5], rank=2)  # non-regular 2-cell
     >>> c1 = Cell((1, 2, 3, 4, 5, 1, 2, 3, 4, 5), regular=False)
     >>> CX.add_cell(c1)
-    >>> CX.add_cell([5, 6, 7, 8],rank=2)
+    >>> CX.add_cell([5, 6, 7, 8], rank=2)
     >>> CX.is_regular
-
-    # Example 5
-    -----------
-    >>> CX = CellComplex()
-    >>> CX.add_cell([1, 2, 3, 4], rank=2, weight=5)
-    >>> CX.add_cell([2, 3, 4, 5], rank=2, weight=10)
-    >>> CX.add_cell([5, 6, 7, 8], rank=2, weight=13)
     """
 
     def __init__(self, cells=None, name=None, regular=True, **attr):
@@ -213,10 +203,10 @@ class CellComplex(Complex):
 
         Returns
         -------
-        _ : bool
+        bool
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex(regular=False)
         >>> CX.add_cell([1, 2, 3, 4], rank=2)
         >>> CX.add_cell([2, 3, 4, 5, 2, 3, 4, 5], rank=2)  # non-regular 2-cell
@@ -247,7 +237,7 @@ class CellComplex(Complex):
 
         Returns
         -------
-        _ : dict_keyiterator
+        dict_keyiterator
             Iterator over nodes.
         """
         return iter(self.nodes)
@@ -262,7 +252,7 @@ class CellComplex(Complex):
 
         Returns
         -------
-        _ : bool
+        bool
             True if item is in self.nodes, False otherwise.
         """
         return item in self.nodes
@@ -323,8 +313,8 @@ class CellComplex(Complex):
         equiv : TYPE
             DESCRIPTION.
 
-        Example
-        -------
+        Examples
+        --------
         >>> cx = CellComplex()
         >>> cx.add_cell ( (1,2,3,4),rank=2 )
         >>> cx.add_cell ( (2,3,4,1),rank=2 )
@@ -359,8 +349,8 @@ class CellComplex(Complex):
     def _remove_equivalent_cells(self):
         """Remove homotopic cells from the cell complex.
 
-        Example
-        -------
+        Examples
+        --------
         >>> cx = CellComplex()
         >>> cx.add_cell ( (1,2,3,4),rank=2 )
         >>> cx.add_cell ( (2,3,4,1),rank=2 )
@@ -400,7 +390,7 @@ class CellComplex(Complex):
 
         Returns
         -------
-        _ : int
+        int
             Number of cells of rank at least rank that contain node.
         """
         return self._G.degree[node]
@@ -458,8 +448,8 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        cell_set : an interable of RankedEntities, optional, default: None
-            If None, then return the number of cells in cell complex.
+        edge_set : an iterable of RankedEntities, optional, default: None
+            If None, then return the number of edges in cell complex.
 
         Returns
         -------
@@ -507,12 +497,9 @@ class CellComplex(Complex):
         node : hashable or Entity
             uid for a node in cell complex or the node Entity
 
-        s : int, list, optional, default : 1
-            Minimum rank of cells shared by neighbors with node.
-
         Returns
         -------
-        _ : list
+        list
             List of neighbors.
         """
         if node not in self.nodes:
@@ -610,15 +597,17 @@ class CellComplex(Complex):
         ----------
         cell : hashable or RankedEntity
             If hashable the cell returned will be empty.
-        uid : unique identifier that identifies the cell
-        rank : rank of a cell, supported ranks is 1 or 2
+        rank : int
+            rank of a cell, supported ranks is 1 or 2
+        check_skeleton : bool, default=False
+            If true, this function checks the skeleton whether the given cell can be added.
 
         Returns
         -------
         Cell Complex : CellComplex
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> c1 = Cell((2, 3, 4), color='black')
         >>> CX.add_cell(c1, weight=3)
@@ -700,10 +689,12 @@ class CellComplex(Complex):
         ----------
         cell_set : iterable of hashables or Cell
             For hashables the cells returned will be empty.
-        rank : integer (optional), default is None
+        rank : int (optional), default is None
                when each element in cell_set is an iterable then
                rank must be a number that indicates the rank
                of the added cells.
+        check_skeleton : bool
+            If true, this function checks the skeleton whether the given cell can be added.
 
         Returns
         -------
@@ -753,10 +744,6 @@ class CellComplex(Complex):
 
     def clear(self):
         """Remove all cells from a cell complex.
-
-        Parameters
-        ----------
-        cell_set : iterable of hashables or RankedEntities
 
         Returns
         -------
@@ -848,8 +835,8 @@ class CellComplex(Complex):
         -------
         None
 
-        Example
-        -------
+        Examples
+        --------
         >>> G = nx.path_graph(3)
         >>> CX = CellComplex(G)
         >>> d = {0: {'color': 'red', 'attr2': 1 }, 1: {'color': 'blue', 'attr2': 3}}
@@ -884,8 +871,8 @@ class CellComplex(Complex):
         -------
         None
 
-        Example
-        -------
+        Examples
+        --------
         >>> G = nx.path_graph(3)
         >>> CX = CellComplex(G)
         >>> d={ (0,1) : {'color':'red','attr2':1 },(1,2): {'color':'blue','attr2':3 } }
@@ -912,7 +899,7 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name.
 
         Returns
@@ -939,8 +926,8 @@ class CellComplex(Complex):
         -------
         None.
 
-        Example
-        -------
+        Examples
+        --------
         After computing some property of the cell of a cell complex, you may want
         to assign a cell attribute to store the value of that property for
         each cell:
@@ -1027,7 +1014,7 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name.
 
         Returns
@@ -1061,9 +1048,10 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name
-        k : integer rank of the k-cell
+        rank : int
+            rank of the k-cell
 
         Returns
         -------
@@ -1120,8 +1108,8 @@ class CellComplex(Complex):
         -------
         None.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import networkx as nx
         >>> G = nx.path_graph(3)
         >>> cx = CellComplex(G)
@@ -1168,11 +1156,14 @@ class CellComplex(Complex):
 
         Parameters
         ----------
+        rank : int
+            The rank for which an incidence matrix should be computed.
+        signed : bool, default=True
+            Whether the returned incidence matrix should be signed (i.e., respect orientations) or unsigned.
         weight : bool, default=False
             If False all nonzero entries are 1.
             If True and self.static all nonzero entries are filled by
             self.cells.cell_weight dictionary values.
-
         index : boolean, optional, default False
             If True return will include a dictionary of node uid : row number
             and cell uid : column number
@@ -1189,22 +1180,20 @@ class CellComplex(Complex):
             list of cells in the complex with the same
             order of the column of the matrix
 
-        Example1
+        Examples
         --------
-            >>> CX = CellComplex()
-            >>> CX.add_cell([1,2,3,4],rank=2)
-            >>> CX.add_cell([3,4,5],rank=2)
-            >>> B0 = CX.incidence_matrix(0)
-            >>> B1 = CX.incidence_matrix(1)
-            >>> B2 = CX.incidence_matrix(2)
-            >>> B1.dot(B2).todense()
-            >>> B0.dot(B1).todense()
+        >>> CX = CellComplex()
+        >>> CX.add_cell([1, 2, 3, 4], rank=2)
+        >>> CX.add_cell([3, 4, 5], rank=2)
+        >>> B0 = CX.incidence_matrix(0)
+        >>> B1 = CX.incidence_matrix(1)
+        >>> B2 = CX.incidence_matrix(2)
+        >>> B1.dot(B2).todense()
+        >>> B0.dot(B1).todense()
 
-        Example2
-        --------
-        ## note that in this example, the first three cells are
-        ## equivalent and hence they have similar incidence to lower edges
-        ## they are incident to
+        Note that in this example, the first three cells are equivalent and hence they have similar incidence to lower
+        edges they are incident to.
+
         >>> import networkx as nx
         >>> G = nx.path_graph(3)
         >>> CX = CellComplex(G)
@@ -1217,9 +1206,8 @@ class CellComplex(Complex):
         >>> B2 = CX.incidence_matrix(2)
         >>> B1.dot(B2).todense()
 
-        Example3
-        --------
-        # non-regular complex example
+        Non-regular cell complex example:
+
         >>> CX = CellComplex(regular=False)
         >>> CX.add_cell([1,2,3,2],rank=2)
         >>> CX.add_cell([3,4,5,3,4,5],rank=2)
@@ -1228,8 +1216,6 @@ class CellComplex(Complex):
         >>> print(B2.todense()) # observe the non-unit entries
         >>> B1.dot(B2).todense()
 
-        Example4
-        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3,4],rank=2)
         >>> CX.add_cell([3,4,5],rank=2)
@@ -1347,8 +1333,8 @@ class CellComplex(Complex):
         -------
         a matrix : scipy.sparse.csr.csr_matrix
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1, 2, 3, 5, 6], rank=2)
         >>> CX.add_cell([1, 2, 4, 5, 3, 0], rank=2)
@@ -1370,7 +1356,7 @@ class CellComplex(Complex):
         Parameters
         ----------
         rank : int, dimension of the Laplacian matrix.
-            Supported dimension are 0,1 and 2
+            Supported dimension are 0, 1 and 2
         signed : bool, is true return absolute value entry of the Laplacian matrix
                        this is useful when one needs to obtain higher-order
                        adjacency matrices from the hodge-laplacian
@@ -1392,12 +1378,12 @@ class CellComplex(Complex):
             list identifying rows with nodes,edges or cells used to index the hodge Laplacian matrix
             depending on the input dimension
 
-        Example1
+        Examples
         --------
         >>> CX = CellComplex()
-        >>> CX.add_cell([1,2,3,4],rank=2)
-        >>> CX.add_cell([3,4,5],rank=2)
-        >>> L1 = CX.hodge_laplacian_matrix(1)
+        >>> CX.add_cell([1, 2, 3, 4], rank=2)
+        >>> CX.add_cell([3, 4, 5], rank=2)
+        >>> CX.hodge_laplacian_matrix(1)
         """
         if rank == 0:  # return L0, the unit graph laplacian
             if index:
@@ -1485,7 +1471,7 @@ class CellComplex(Complex):
             list identifying rows with nodes,edges or cells used to index the hodge Laplacian matrix
             dependeing on the input dimension
 
-        Example1
+        Examples
         --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3,4],rank=2)
@@ -1555,8 +1541,8 @@ class CellComplex(Complex):
             list identifying rows with nodes,edges or cells used to index the hodge Laplacian matrix
             dependeing on the input dimension
 
-        Example
-        -------
+        Examples
+        --------
         >>> import networkx as nx
         >>> G = nx.path_graph(3)
         >>> CX = CellComplex(G)
@@ -1645,8 +1631,8 @@ class CellComplex(Complex):
     def cell_adjacency_matrix(self, signed=True, weight=None, index=False):
         """Compute adjacency matrix.
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3],rank=2)
         >>> CX.add_cell([1,4],rank=1)
@@ -1692,8 +1678,8 @@ class CellComplex(Complex):
         -------
         new cell complex : CellComplex
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> c1 = Cell((1, 2, 3))
         >>> c2 = Cell((1, 2, 4))
@@ -1728,13 +1714,14 @@ class CellComplex(Complex):
         node_set: iterable of hashables
             References a subset of elements of self.nodes
 
-        name: string, optional, default: None
+        name: str, optional
 
         Returns
         -------
         new Cell Complex : Cellcomplex
 
-        Example
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> c1 = Cell((1, 2, 3))
         >>> c2 = Cell((1, 2, 4))
@@ -1762,8 +1749,8 @@ class CellComplex(Complex):
         The rank of an element in a cell complex is its dimension, so vertices have rank 0,
         edges have rank 1, and faces have rank 2.
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3,4],rank=2)
         >>> CX.add_cell([2,3,4,5],rank=2)
@@ -1776,8 +1763,8 @@ class CellComplex(Complex):
     def to_hypergraph(self):
         """Convert to hypergraph.
 
-        Example
-        -------
+        Examples
+        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3,4],rank=2)
         >>> CX.add_cell([2,3,4,5],rank=2)
@@ -2122,7 +2109,7 @@ class CellComplex(Complex):
             a node in the CX
         target : node.uid or node
             a node in the CX
-        s : positive integer
+        s : int
             the number of cells
 
         Returns
@@ -2166,7 +2153,7 @@ class CellComplex(Complex):
             an cell in the cell complex
         target : cell.uid or cell
             an cell in the cell complex
-        s : positive integer
+        s : int
             the number of intersections between pairwise consecutive cells
 
         Returns

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -547,7 +547,7 @@ class CombinatorialComplex(Complex):
         None.
 
         Examples
-        -------
+        --------
         After computing some property of the cell of a combinatorial complex, you may want
         to assign a cell attribute to store the value of that property for
         each cell:

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -28,7 +28,7 @@ __all__ = ["CombinatorialComplex"]
 
 
 class CombinatorialComplex(Complex):
-    r"""Class for Combinatorial Complex.
+    """Class for Combinatorial Complex.
 
     A Combinatorial Complex (CC) is a triple CC = (S, X, rk) where:
     -  S is an abstract set of entities,
@@ -390,12 +390,12 @@ class CombinatorialComplex(Complex):
         ----------
         node : hashable
             Identifier for the node.
-        rank : positive integer, optional, default: 1
+        rank : int, optional, default: 1
             Smallest size of cell to consider in degree
 
         Returns
         -------
-        _ : int
+        int
             Number of cells of certain rank that contain node.
         """
         if node in self.nodes:
@@ -546,9 +546,8 @@ class CombinatorialComplex(Complex):
         -------
         None.
 
-        Example
-        ------
-
+        Examples
+        -------
         After computing some property of the cell of a combinatorial complex, you may want
         to assign a cell attribute to store the value of that property for
         each cell:
@@ -563,10 +562,8 @@ class CombinatorialComplex(Complex):
         'green'
 
         If you provide a dictionary of dictionaries as the second argument,
-        the entire dictionary will be used to update edge attributes::
+        the entire dictionary will be used to update edge attributes:
 
-        Examples
-        --------
         >>> G = nx.path_graph(3)
         >>> CC = NestedCombinatorialComplex(G)
         >>> d = {(1, 2): {'color': 'red','attr2': 1}, (0, 1): {'color': 'blue', 'attr2': 3}}
@@ -597,7 +594,7 @@ class CombinatorialComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name
 
         Returns
@@ -631,9 +628,10 @@ class CombinatorialComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name.
-        rank : integer rank of the k-cell
+        rank : int
+            rank of the k-cell
 
         Returns
         -------
@@ -1083,7 +1081,7 @@ class CombinatorialComplex(Complex):
         If index if False
             adjacency_matrix : scipy.sparse.csr.csr_matrix
 
-        Example
+        Examples
         --------
         >>> G = Graph() # networkx graph
         >>> G.add_edge(0, 1)
@@ -1241,7 +1239,7 @@ class CombinatorialComplex(Complex):
         node_set: iterable of hashables
             References a subset of elements of self.nodes
 
-        name: string, optional, default: None
+        name: str, optional
 
         Returns
         -------
@@ -1263,8 +1261,8 @@ class CombinatorialComplex(Complex):
         CC such that the edges of the graph are ranked 1
         and the nodes are ranked 0.
 
-        Example
-        ------
+        Examples
+        --------
         >>> from networkx import Graph
         >>> G = Graph()
         >>> G.add_edge(0, 1)
@@ -1284,8 +1282,8 @@ class CombinatorialComplex(Complex):
     def to_hypergraph(self):
         """Convert a combinatorial complex to a hypergraph.
 
-        Example
-        -------
+        Examples
+        --------
         >>> CC = CombinatorialComplex(cells=E)
         >>> HG = CC.to_hypergraph()
         """
@@ -1314,8 +1312,8 @@ class CombinatorialComplex(Complex):
         such that every consecutive pair of nodes v(i),v(i+1)
         share at least s cell.
 
-        Example
-        -------
+        Examples
+        --------
         >>> CC = CombinatorialComplex(cells=E)
         """
         B = self.incidence_matrix(rank=0, to_rank=None, incidence_type="up")
@@ -1633,7 +1631,7 @@ class CombinatorialComplex(Complex):
             a node in the CC
         target : node.uid or node
             a node in the CC
-        s : positive integer
+        s : int
             the number of cells
 
         Returns
@@ -1664,11 +1662,9 @@ class CombinatorialComplex(Complex):
         ----------
         source : cell.uid or cell
             an cell in the combinatorial complex
-
         target : cell.uid or cell
             an cell in the combinatorial complex
-
-        s : positive integer
+        s : int
             the number of intersections between pairwise consecutive cells
 
         Returns

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -41,84 +41,84 @@ class Complex:
     @property
     @abc.abstractmethod
     def nodes(self):
-        r"""Return the node container."""
+        """Return the node container."""
         pass
 
     @property
     @abc.abstractmethod
     def dim(self):
-        r"""Return dimension of the complex."""
+        """Return dimension of the complex."""
         pass
 
     @abc.abstractmethod
     def shape(self):
-        r"""Return number of cells for each rank."""
+        """Return number of cells for each rank."""
         pass
 
     @abc.abstractmethod
     def skeleton(self, rank):
-        r"""Return dimension of the complex."""
+        """Return dimension of the complex."""
         pass
 
     @abc.abstractmethod
     def __str__(self):
-        r"""Print basic string representation."""
+        """Print basic string representation."""
         pass
 
     @abc.abstractmethod
     def __repr__(self):
-        r"""Print detailed string representation."""
+        """Print detailed string representation."""
         pass
 
     @abc.abstractmethod
     def __len__(self):
-        r"""Return number of nodes."""
+        """Return number of nodes."""
         pass
 
     def _clear_cache(self):
-        r"""Clear cache."""
+        """Clear cache."""
         self.cache = {}
 
     @abc.abstractmethod
     def clone(self):
-        r"""Clone complex."""
+        """Clone complex."""
 
     @abc.abstractmethod
     def __iter__(self):
-        r"""Return an iterator over the nodes."""
+        """Return an iterator over the nodes."""
         pass
 
     @abc.abstractmethod
     def __contains__(self, item):
-        r"""Check whether the complex contains an item."""
+        """Check whether the complex contains an item."""
         pass
 
     @abc.abstractmethod
     def __getitem__(self, node):
-        r"""Get item."""
+        """Get item."""
         pass
 
     @abc.abstractmethod
     def remove_nodes(self, node_set):
-        r"""Return dimension of the complex."""
+        """Return dimension of the complex."""
         pass
 
     @abc.abstractmethod
     def add_node(self, node):
-        r"""Add node to the complex."""
+        """Add node to the complex."""
         pass
 
     @abc.abstractmethod
     def incidence_matrix(self):
-        r"""Return incidence matrix of the complex."""
+        """Return incidence matrix of the complex."""
         pass
 
     @abc.abstractmethod
     def adjacency_matrix(self):
-        r"""Return adjacency matrix of the complex."""
+        """Return adjacency matrix of the complex."""
         pass
 
     @abc.abstractmethod
     def coadjacency_matrix(self):
-        r"""Return coadjacency matrix of the complex."""
+        """Return coadjacency matrix of the complex."""
         pass

--- a/toponetx/classes/node.py
+++ b/toponetx/classes/node.py
@@ -49,7 +49,7 @@ class NodeView:
 
         Returns
         -------
-        _ : dict or list or dicts
+        dict or list
             Dict of properties associated with that cells.
         """
         if isinstance(cell, self.cell_type):

--- a/toponetx/classes/reportview.py
+++ b/toponetx/classes/reportview.py
@@ -21,7 +21,7 @@ __all__ = ["HyperEdgeView", "CellView", "SimplexView"]
 
 
 class CellView:
-    r"""A CellView class for cells of a CellComplex.
+    """A CellView class for cells of a CellComplex.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ class CellView:
         self._cells = dict()
 
     def __getitem__(self, cell):
-        r"""Return the properties of a given cell.
+        """Return the properties of a given cell.
 
         Parameters
         ----------
@@ -92,14 +92,14 @@ class CellView:
             raise KeyError("input must be a tuple, list or a cell")
 
     def __len__(self):
-        r"""Return the number of cells in the cell view."""
+        """Return the number of cells in the cell view."""
         if len(self._cells) == 0:
             return 0
         else:
             return np.sum([len(self._cells[cell]) for cell in self._cells])
 
     def __iter__(self):
-        r"""Iterate over all cells in the cell view."""
+        """Iterate over all cells in the cell view."""
         return iter(
             [
                 self._cells[cell][key]
@@ -109,7 +109,7 @@ class CellView:
         )
 
     def __contains__(self, e):
-        r"""Check if a given element is in the cell view.
+        """Check if a given element is in the cell view.
 
         Parameters
         ----------
@@ -130,11 +130,11 @@ class CellView:
             return False
 
     def __repr__(self):
-        r"""Return a string representation of the cell view."""
+        """Return a string representation of the cell view."""
         return f"CellView({[self._cells[cell][key] for cell in self._cells for key in  self._cells[cell]] })"
 
     def __str__(self):
-        r"""Return a string representation of the cell view."""
+        """Return a string representation of the cell view."""
         return f"CellView({[self._cells[cell][key] for cell in self._cells for key in  self._cells[cell]] })"
 
 

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -13,28 +13,31 @@ class Simplex:
     """
     A class representing a simplex in a simplicial complex.
 
-    This class represents a simplex in a simplicial complex, which is a set of nodes with a specific dimension. The simplex
-    is immutable, and the nodes in the simplex must be hashable and unique.
+    This class represents a simplex in a simplicial complex, which is a set of nodes with a specific dimension. The
+    simplex is immutable, and the nodes in the simplex must be hashable and unique.
 
-    :param elements: The nodes in the simplex.
-    :type elements: any iterable of hashables
-    :param name: A name for the simplex, default is None.
-    :type name: str, optional
-    :param construct_tree: If True, construct the entire simplicial tree for the simplex. Default is True.
-    :type construct_tree: bool, optional
-    :param attr: Additional attributes to be associated with the simplex.
-    :type attr: keyword arguments, optional
+    Parameters
+    ----------
+    elements: Iterable
+        The nodes in the simplex.
+    name : str, optional
+        A name for the simplex.
+    construct_tree : bool, default=True
+        If True, construct the entire simplicial tree for the simplex.
+    attr : keyword arguments, optional
+        Additional attributes to be associated with the simplex.
 
-    :Example:
-        >>> # Create a 0-dimensional simplex (point)
-        >>> s = Simplex((1,))
-        >>> # Create a 1-dimensional simplex (line segment)
-        >>> s = Simplex((1, 2))
-        >>> # Create a 2-dimensional simplex (triangle)
-        >>> simplex1 = Simplex((1, 2, 3))
-        >>> simplex2 = Simplex(("a", "b", "c"))
-        >>> # Create a 3-dimensional simplex (tetrahedron)
-        >>> simplex3 = Simplex((1, 2, 4, 5), weight=1)
+    Examples
+    --------
+    >>> # Create a 0-dimensional simplex (point)
+    >>> s = Simplex((1,))
+    >>> # Create a 1-dimensional simplex (line segment)
+    >>> s = Simplex((1, 2))
+    >>> # Create a 2-dimensional simplex (triangle)
+    >>> simplex1 = Simplex((1, 2, 3))
+    >>> simplex2 = Simplex(("a", "b", "c"))
+    >>> # Create a 3-dimensional simplex (tetrahedron)
+    >>> simplex3 = Simplex((1, 2, 4, 5), weight=1)
     """
 
     def __init__(self, elements, name=None, construct_tree=True, **attr):
@@ -111,7 +114,7 @@ class Simplex:
 
         Returns
         -------
-        _ : frozenset[Simplex]
+        frozenset[Simplex]
             The set of faces of the simplex.
         """
         if self.construct_tree:

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -664,7 +664,6 @@ class SimplicialComplex(Complex):
 
         Examples
         --------
-
         After computing some property of the simplex of a simplicial complex, you may want
         to assign a simplex attribute to store the value of that property for
         each simplex:

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -70,7 +70,7 @@ class SimplicialComplex(Complex):
         list of maximal simplices that define the simplicial complex
     name : hashable, optional, default: None
         If None then a placeholder '' will be inserted as name
-    mode : string, optional, default 'normal'.
+    mode : str, optional, default 'normal'.
         computational mode, available options are "normal" or "gudhi".
         default is 'normal'.
 
@@ -88,10 +88,12 @@ class SimplicialComplex(Complex):
 
     Examples
     --------
-    # defining a simplicial complex using a set of maximal simplices.
+    Define a simplicial complex using a set of maximal simplices:
+
     >>> SC = SimplicialComplex([[1, 2, 3], [2, 3, 5], [0, 1]])
 
-    # compatabiltiy with networkx
+    TopoNetX is also compatible with NetworkX, allowing users to create a simplicial complex from a NetworkX graph:
+
     >>> G = Graph() # networkx G
     >>> G.add_edge(0, 1, weight=4)
     >>> G.add_edge(0, 3)
@@ -233,7 +235,7 @@ class SimplicialComplex(Complex):
 
         Returns
         -------
-        _ : int
+        int
             Total number of simplices in all dimensions.
         """
         return np.sum(self.shape)
@@ -496,10 +498,10 @@ class SimplicialComplex(Complex):
         Examples
         --------
         >>> SC = SimplexView()
-        >>> SC.insert_simplex ( (1,2,3,4),weight=1 )
-        >>> c1=Simplex((1,2,3,4,5))
+        >>> SC.insert_simplex((1, 2, 3, 4), weight=1)
+        >>> c1=Simplex((1, 2, 3, 4, 5))
         >>> SC.insert_simplex(c1)
-        >>> SC.remove_maximal_simplex((1,2,3,4,5))
+        >>> SC.remove_maximal_simplex((1, 2, 3, 4, 5))
         """
         if isinstance(simplex, Iterable):
             if not isinstance(simplex, Simplex):
@@ -616,7 +618,7 @@ class SimplicialComplex(Complex):
 
         Returns
         -------
-        _ : list of tuples(simplex).
+        list of tuples(simplex).
         """
         entire_tree = self.get_boundaries(
             self.get_maximal_simplices_of_simplex(simplex)
@@ -660,8 +662,8 @@ class SimplicialComplex(Complex):
         -------
         None.
 
-        Example 1
-        ---------
+        Examples
+        --------
 
         After computing some property of the simplex of a simplicial complex, you may want
         to assign a simplex attribute to store the value of that property for
@@ -677,10 +679,8 @@ class SimplicialComplex(Complex):
         'red'
 
         If you provide a dictionary of dictionaries as the second argument,
-        the entire dictionary will be used to update simplex attributes::
+        the entire dictionary will be used to update simplex attributes:
 
-        Example 2
-        ---------
         >>> SC = SimplicialComplex()
         >>> SC.add_simplex([1, 3, 4])
         >>> SC.add_simplex([1, 2, 3])
@@ -718,7 +718,7 @@ class SimplicialComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name.
 
         Returns
@@ -734,7 +734,6 @@ class SimplicialComplex(Complex):
         >>> d = {(1): 'red', (2): 'blue', (3): 'black'}
         >>> SC.set_simplex_attributes(d, name='color')
         >>> SC.get_node_attributes('color')
-        >>>
         'blue'
         """
         return {tuple(n): self[n][name] for n in self.skeleton(0) if name in self[n]}
@@ -744,9 +743,10 @@ class SimplicialComplex(Complex):
 
         Parameters
         ----------
-        name : string
+        name : str
            Attribute name
-        rank : integer rank of the cell
+        rank : int
+            rank of the cell
 
         Returns
         -------
@@ -798,8 +798,8 @@ class SimplicialComplex(Complex):
 
         Getting the matrix that correpodnds to the boundary matrix of the input SC.
 
-        Example
-        -------
+        Examples
+        --------
         >>> SC = SimplicialComplex()
         >>> SC.add_simplex([1, 2, 3, 4])
         >>> SC.add_simplex([1, 2, 4])
@@ -928,7 +928,6 @@ class SimplicialComplex(Complex):
                 return column, L_hodge
             else:
                 return L_hodge
-
         elif rank == self.dim:
             row, column, B = self.incidence_matrix(rank, weight=weight, index=True)
             L_hodge = B.transpose() @ B
@@ -938,7 +937,6 @@ class SimplicialComplex(Complex):
                 return column, L_hodge
             else:
                 return L_hodge
-
         else:
             raise ValueError(
                 f"Rank should be larger than 0 and <= {self.dim} (maximal dimension simplices), got {rank}"
@@ -949,7 +947,7 @@ class SimplicialComplex(Complex):
             return abs(L_hodge)
 
     def normalized_laplacian_matrix(self, rank, weight=None):
-        r"""Return the normalized hodge Laplacian matrix of G.
+        """Return the normalized hodge Laplacian matrix of G.
 
         The normalized hodge Laplacian is the matrix
 
@@ -963,20 +961,19 @@ class SimplicialComplex(Complex):
         ----------
         rank : int
             Rank of the hodge laplacian matrix
-        weight : string or None, optional (default='weight')
+        weight : str or None, optional (default='weight')
             The edge data key used to compute each value in the matrix.
             If None, then each edge has weight 1.
 
         Returns
         -------
-        _ : Scipy sparse matrix
+        Scipy sparse matrix
             The normalized hodge Laplacian matrix.
 
-        Example 1
-        ---------
+        Examples
+        --------
         >>> SC = SimplicialComplex([[1, 2, 3], [2, 3, 5], [0, 1]])
-        >>> L1_norm = SC.normalized_laplacian_matrix(1)
-        >>> L1_norm
+        >>> SC.normalized_laplacian_matrix(1)
         """
         import numpy as np
         import scipy as sp
@@ -1185,14 +1182,14 @@ class SimplicialComplex(Complex):
         -------
         new simplicial Complex : SimplicialComplex
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((1, 2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
         >>> SC1 = SC.restrict_to_simplices([c1, (2, 4)])
-        >>> new_sc = SC1.simplices
+        >>> SC1.simplices
         """
         rns = []
         for cell in cell_set:
@@ -1212,20 +1209,20 @@ class SimplicialComplex(Complex):
         ----------
         node_set: iterable of hashables
             References a subset of elements of self.nodes
-
-        name: string, optional, default: None
+        name: str, optional
+            The name of the new simplicial complex.
 
         Returns
         -------
         new Simplicial Complex : SimplicialComplex
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((1, 2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
-        >>> new_sc = SC.restrict_to_nodes([1, 2, 3, 4])
+        >>> SC.restrict_to_nodes([1, 2, 3, 4])
         """
         simplices = []
         node_set = set(node_set)
@@ -1242,8 +1239,8 @@ class SimplicialComplex(Complex):
     def get_all_maximal_simplices(self):
         """Get all maximal simplices.
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((2, 5))
@@ -1293,8 +1290,8 @@ class SimplicialComplex(Complex):
     def from_gudhi(tree):
         """Import from gudhi.
 
-        Example
-        -------
+        Examples
+        --------
         >>> from gudhi import SimplexTree
         >>> tree = SimplexTree()
         >>> tree.insert([1,2,3,5])
@@ -1308,8 +1305,8 @@ class SimplicialComplex(Complex):
     def from_trimesh(mesh):
         """Import from trimesh.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import trimesh
         >>> mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
                                faces=[[0, 1, 2]],
@@ -1408,8 +1405,8 @@ class SimplicialComplex(Complex):
     def to_spharapy(self, vertex_position_name="position"):
         """Convert to sharapy.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import spharapy.trimesh as tm
         >>> import spharapy.spharabasis as sb
         >>> import spharapy.datasets as sd
@@ -1471,10 +1468,11 @@ class SimplicialComplex(Complex):
         Examples
         --------
         >>> G = nx.Graph()  # or DiGraph, MultiGraph, MultiDiGraph, etc
-        >>> G.add_edge('1', '2', weight=2)
-        >>> G.add_edge('3', '4', weight=4)
+        >>> G.add_edge(1, 2, weight=2)
+        >>> G.add_edge(3, 4, weight=4)
         >>> SC = SimplicialComplex.from_nx_graph(G)
-        >>> SC[('1','2')]['weight']
+        >>> SC[(1, 2)]["weight"]
+        2
         """
         return SimplicialComplex(G, name=G.name)
 
@@ -1504,15 +1502,15 @@ class SimplicialComplex(Complex):
 
         Returns
         -------
-        _ : SimplicialComplex
-        Simplicial complex closure of the hypergraph.
+        SimplicialComplex
+            Simplicial complex closure of the hypergraph.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import hypernetx as hnx
-        >>> hg = hnx.Hypergraph( [ [1,2,3,4],[1,2,3] ], static=True)
+        >>> hg = hnx.Hypergraph([[1, 2, 3, 4], [1, 2, 3]], static=True)
         >>> sc = SimplicialComplex.simplicial_closure_of_hypergraph(hg)
-        >>> print(sc.simplices)
+        >>> sc.simplices
         """
         edges = H.edges
         lst = []
@@ -1523,8 +1521,8 @@ class SimplicialComplex(Complex):
     def to_cell_complex(self):
         """Convert a simplicial complex to a cell complex.
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((2, 5))
@@ -1538,8 +1536,8 @@ class SimplicialComplex(Complex):
     def to_hypergraph(self):
         """Convert a simplicial complex to a hyperG.
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((2, 5))
@@ -1561,13 +1559,11 @@ class SimplicialComplex(Complex):
             when True returns DynamicCombinatorialComplex
             when False returns CombinatorialComplex
 
-        Example
-        -------
+        Examples
+        --------
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 3))
-
         >>> c3 = Simplex((1, 2, 4))
-        >>> c4 = Simplex((2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
         >>> CC = SC.to_combinatorial_complex()
         """

--- a/toponetx/datasets/utils.py
+++ b/toponetx/datasets/utils.py
@@ -17,7 +17,7 @@ def load_ppi():
 
     Returns
     -------
-    _ : networkx.Graph
+    networkx.Graph
         Graph with nodes that are proteins and edges corresponding to their
         chemical interactions.
     """

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -21,7 +21,7 @@ def graph_2_neighbor_complex(G):
 
     Returns
     -------
-    _ : SimplicialComplex
+    SimplicialComplex
         The neighbor complex of the graph.
 
     Notes
@@ -51,7 +51,7 @@ def graph_2_clique_complex(G, max_dim=None):
 
     Returns
     -------
-    _ : SimplicialComplex
+    SimplicialComplex
         The clique simplicial complex of dimension dim of the graph G.
     """
     if max_dim is None:

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Tuple
 def sparse_array_to_neighborhood_list(
     sparse_array, src_dict=None, dst_dict=None
 ) -> zip:
-    r"""Convert sparse array to neighborhood list for arbitrary higher order structures.
+    """Convert sparse array to neighborhood list for arbitrary higher order structures.
 
     Notes
     -----
@@ -57,7 +57,7 @@ def sparse_array_to_neighborhood_list(
 def neighborhood_list_to_neighborhood_dict(
     n_list: List[Tuple[int, int]], src_dict=None, dst_dict=None
 ) -> Dict[int, List[int]]:
-    r"""Convert neighborhood list to neighborhood dictionary for arbitrary higher order structures.
+    """Convert neighborhood list to neighborhood dictionary for arbitrary higher order structures.
 
     Notes
     -----
@@ -83,7 +83,7 @@ def neighborhood_list_to_neighborhood_dict(
 def sparse_array_to_neighborhood_dict(
     sparse_array, src_dict=None, dst_dict=None
 ) -> Dict[int, List[int]]:
-    r"""Convert sparse array to neighborhood dictionary for arbitrary higher order structures.
+    """Convert sparse array to neighborhood dictionary for arbitrary higher order structures.
 
     Notes
     -----


### PR DESCRIPTION
These changes format the docstrings to follow NumPy's style guide in more places. In particular:

- There is only one section `Examples` containing all examples. It is also called `Examples` even if there is only one example (currently).
- Use built-in Python types (e.g., bool instead of boolean).