### PR TITLE
[BREAKING CHANGES] Clean up adjacency and related methods

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -275,7 +275,7 @@ class TestCellComplex(unittest.TestCase):
         CX = CellComplex()
         CX.add_cell([1, 2, 3], rank=2)
         A = np.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]])
-        np.testing.assert_array_equal(CX.adjacency_matrix(0).todense(), A)
+        np.testing.assert_array_equal(CX.adjacency_matrix(0, up=True).todense(), A)
 
     def test_adjacency_matrix_cell_complex_with_multiple_cell(self):
         """Test adjacency matrix for a cell complex with multiple cells."""
@@ -293,7 +293,7 @@ class TestCellComplex(unittest.TestCase):
                 [0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
             ]
         )
-        np.testing.assert_array_equal(CX.adjacency_matrix(rank=0).toarray(), A)
+        np.testing.assert_array_equal(CX.adjacency_matrix(rank=0, up=True).toarray(), A)
 
     def test_up_laplacian_matrix_empty_cell_complex(self):
         """Test up laplacian matrix for an empty cell complex."""
@@ -469,7 +469,7 @@ class TestCellComplex(unittest.TestCase):
         cc = CellComplex()
         cc.add_cell([1, 2, 3], rank=2)
         A = np.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]])
-        np.testing.assert_array_equal(cc.adjacency_matrix(0).todense(), A)
+        np.testing.assert_array_equal(cc.adjacency_matrix(0, up=True).todense(), A)
 
     def test_coadjccency_matrix_abstrcct_cell_with_one_cell(self):
         """Test coadjccency matrix for an abstrcct cell with one cell."""

--- a/toponetx/algorithms/spectrum.py
+++ b/toponetx/algorithms/spectrum.py
@@ -6,6 +6,7 @@ from numpy import linalg as LA
 from scipy.sparse import diags
 
 from toponetx.classes.cell_complex import CellComplex
+from toponetx.classes import CombinatorialComplex
 from toponetx.classes.simplicial_complex import SimplicialComplex
 from toponetx.datasets.mesh_complex import stanford_bunny
 
@@ -247,15 +248,15 @@ def simplicial_complex_hodge_laplacian_spectrum(
     return laplacian_spectrum(SC.hodge_laplacian_matrix(rank=rank))
 
 
-def cell_complex_adjacency_spectrum(CX: CellComplex, rank, weight="weight"):
+def cell_complex_adjacency_spectrum(CX: CellComplex, rank, up=False):
     """Return eigenvalues of the Laplacian of G.
 
     Parameters
     ----------
     matrix : scipy sparse matrix
 
-    weight : string or None, optional (default='weight')
-       If None, then each cell has weight 1.
+    up : bool, default False
+        whether to take the upper or lower adjacency
 
     Returns
     -------
@@ -270,7 +271,7 @@ def cell_complex_adjacency_spectrum(CX: CellComplex, rank, weight="weight"):
     >>> CX.add_cell([5,6,7,8],rank=2)
     >>> cell_complex_adjacency_spectrum(CX,1)
     """
-    return laplacian_spectrum(CX.adjacency_matrix(rank=rank, weight=weight))
+    return laplacian_spectrum(CX.adjacency_matrix(rank=rank, up=up))
 
 
 def simplicial_complex_adjacency_spectrum(
@@ -293,8 +294,8 @@ def simplicial_complex_adjacency_spectrum(
     return laplacian_spectrum(SC.adjacency_matrix(rank=dim, weight=weight))
 
 
-def combinatorial_complex_adjacency_spectrum(CC, r, k, weight="weight"):
-    """Return eigenvalues of the Laplacian of G.
+def combinatorial_complex_adjacency_spectrum(CC: CombinatorialComplex, r, k):
+    """Return eigenvalues of the adjacency matrix of CC.
 
     Parameters
     ----------
@@ -313,4 +314,4 @@ def combinatorial_complex_adjacency_spectrum(CC, r, k, weight="weight"):
     >>> CC = CombinatorialComplex(cells=[[1,2,3],[2,3], [0] ],ranks=[2,1,0] )
     >>> s = laplacian_spectrum( CC.adjacency_matrix( 0,2) )
     """
-    return laplacian_spectrum(CC.adjacency_matrix(r, k, weight=weight))
+    return laplacian_spectrum(CC.adjacency_matrix(r, k))

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -29,6 +29,7 @@ from toponetx.classes.combinatorial_complex import CombinatorialComplex
 from toponetx.classes.complex import Complex
 from toponetx.classes.reportview import CellView
 from toponetx.exception import TopoNetXError
+from toponetx.utils import incidence_to_adjacency
 
 __all__ = ["CellComplex"]
 
@@ -1325,45 +1326,6 @@ class CellComplex(Complex):
         else:
             raise ValueError(f"Only dimensions 0, 1 and 2 are supported, got {rank}.")
 
-    @staticmethod
-    def _incidence_to_adjacency(B, weight=False):
-        """Get adjacency matrix from incidence.
-
-        Get the adjacency matrix from the
-        boolean incidence matrix for s-metrics.
-
-        Self loops are not supported.
-        The adjacency matrix will define an s-linegraph.
-
-        Parameters
-        ----------
-        B : scipy.sparse.csr.csr_matrix
-            Incidence matrix of 0's and 1's.
-        weight : bool, dict optional, default=True
-            If False all nonzero entries are 1.
-            Otherwise, weight will be as in product.
-
-        Returns
-        -------
-        a matrix : scipy.sparse.csr.csr_matrix
-
-        Example
-        -------
-        >>> CX = CellComplex()
-        >>> CX.add_cell([1, 2, 3, 5, 6], rank=2)
-        >>> CX.add_cell([1, 2, 4, 5, 3, 0], rank=2)
-        >>> CX.add_cell([1, 2, 4, 9, 3, 0], rank=2)
-        >>> B1 = CX.incidence_matrix(1, signed=False)
-        >>> A1 = CX._incidence_to_adjacency(B1)
-        """
-        B = csr_matrix(B)
-        weight = False  # currently weighting is not supported
-        B = abs(B)  # make sure the incidence matrix has only positive entries
-        if weight is False:
-            A = B.dot(B.transpose())
-            A.setdiag(0)
-        return A
-
     def hodge_laplacian_matrix(self, rank, signed=True, weight=None, index=False):
         """Compute the hodge-laplacian matrix for the CX.
 
@@ -1583,21 +1545,27 @@ class CellComplex(Complex):
         else:
             return L_down
 
-    def adjacency_matrix(self, rank, signed=False, weight=None, index=False):
+    def adjacency_matrix(self, rank, up=False, index=False):
         """Compute adjacency matrix for a given rank."""
-        weight = None  # this feature is not supported in this version
+        if up:
+            rank += 1
 
-        ind, L_up = self.up_laplacian_matrix(
-            rank, signed=signed, weight=weight, index=True
-        )
-        L_up.setdiag(0)
-
-        if not signed:
-            L_up = abs(L_up)
         if index:
-            return ind, L_up
+            lower_ind, ind, incidence = self.incidence_matrix(
+                rank, signed=False, index=True
+            )
         else:
-            return L_up
+            incidence = self.incidence_matrix(rank, signed=False)
+
+        if up:
+            incidence = incidence.T
+            if index:
+                ind = lower_ind
+
+        if index:
+            return ind, incidence_to_adjacency(incidence)
+        else:
+            return incidence_to_adjacency(incidence)
 
     def coadjacency_matrix(self, rank, signed=False, weight=None, index=False):
         """Compute coadjacency matrix for a given rank."""
@@ -1641,42 +1609,6 @@ class CellComplex(Complex):
             return np.power(A, k) @ coB
         else:
             return np.power(A, k) @ coB + np.power(coA, k) @ coB
-
-    def cell_adjacency_matrix(self, signed=True, weight=None, index=False):
-        """Compute adjacency matrix.
-
-        Example
-        -------
-        >>> CX = CellComplex()
-        >>> CX.add_cell([1,2,3],rank=2)
-        >>> CX.add_cell([1,4],rank=1)
-        >>> A = CX.cell_adjacency_matrix()
-        """
-        CX = self.to_combinatorial_complex()
-
-        B = CX.incidence_matrix(0, None, incidence_type="up", index=index)
-        if index:
-
-            A = CX._incidence_to_adjacency(B[0].transpose())
-
-            return A, B[2]
-        else:
-            A = CX._incidence_to_adjacency(B.transpose())
-            return A
-
-    def node_adjacency_matrix(self, index=False, s=1, weight=False):
-        """Compute node adjacency matrix."""
-        CX = self.to_combinatorial_complex()
-
-        B = CX.incidence_matrix(0, None, incidence_type="up", index=index)
-        if index:
-
-            A = CX._incidence_to_adjacency(B[0], s=s)
-
-            return A, B[1]
-        else:
-            A = CX._incidence_to_adjacency(B, s=s)
-            return A
 
     def restrict_to_cells(self, cell_set, name=None):
         """Construct cell complex using a subset of the cells in cell complex.
@@ -1897,7 +1829,7 @@ class CellComplex(Complex):
             components of CX.
         """
         if cells:
-            A, coldict = self.cell_adjacency_matrix(s=s, index=True)
+            A, coldict = self.adjacency_matrix(rank=2, index=True)
             G = nx.from_scipy_sparse_matrix(A)
 
             for c in nx.connected_components(G):
@@ -1905,7 +1837,7 @@ class CellComplex(Complex):
                     continue
                 yield {coldict[n] for n in c}
         else:
-            A, rowdict = self.node_adjacency_matrix(s=s, index=True)
+            A, rowdict = self.adjacency_matrix(rank=0, up=True, index=True)
             G = nx.from_scipy_sparse_matrix(A)
             for c in nx.connected_components(G):
                 if not return_singletons:
@@ -2002,7 +1934,7 @@ class CellComplex(Complex):
         """
         return self.s_component_subgraphs(return_singletons=return_singletons)
 
-    def node_diameters(self, s=1):
+    def node_diameters(self):
         """Return the node diameters of the connected components in cell complex.
 
         Parameters
@@ -2010,7 +1942,7 @@ class CellComplex(Complex):
         list of the diameters of the s-components and
         list of the s-component nodes
         """
-        A, coldict = self.node_adjacency_matrix(s=s, index=True)
+        A, coldict = self.adjacency_matrix(rank=0, up=True, index=True)
         G = nx.from_scipy_sparse_matrix(A)
         diams = []
         comps = []
@@ -2041,7 +1973,7 @@ class CellComplex(Complex):
         list of component : list
             List of the cell uids in the s-cell component subgraphs.
         """
-        A, coldict = self.cell_adjacency_matrix(s=s, index=True)
+        A, coldict = self.adjacency_matrix(rank=2, index=True)
         G = nx.from_scipy_sparse_matrix(A)
         diams = []
         comps = []
@@ -2055,7 +1987,7 @@ class CellComplex(Complex):
         loc = np.argmax(diams)
         return diams[loc], diams, comps
 
-    def diameter(self, s=1):
+    def diameter(self):
         """Return length of the longest shortest s-walk between nodes.
 
         Parameters
@@ -2078,7 +2010,7 @@ class CellComplex(Complex):
         nodes v_start, v_1, v_2, ... v_n-1, v_end such that consecutive nodes
         are s-adjacent. If the graph is not connected, an error will be raised.
         """
-        A = self.node_adjacency_matrix(s=s)
+        A = self.adjacency_matrix(rank=0, up=True)
         G = nx.from_scipy_sparse_matrix(A)
         if nx.is_connected(G):
             return nx.diameter(G)
@@ -2107,7 +2039,7 @@ class CellComplex(Complex):
         cells e_start, e_1, e_2, ... e_n-1, e_end such that consecutive cells
         are s-adjacent. If the graph is not connected, an error will be raised.
         """
-        A = self.cell_adjacency_matrix(s=s)
+        A = self.adjacency_matrix(rank=2, up=False)
         G = nx.from_scipy_sparse_matrix(A)
         if nx.is_connected(G):
             return nx.diameter(G)
@@ -2147,7 +2079,7 @@ class CellComplex(Complex):
             source = source.uid
         if isinstance(target, Cell):
             target = target.uid
-        A, rowdict = self.node_adjacency_matrix(s=s, index=True)
+        A, rowdict = self.adjacency_matrix(rank=0, up=True, index=True)
         G = nx.from_scipy_sparse_matrix(A)
         rkey = {v: k for k, v in rowdict.items()}
         try:
@@ -2194,7 +2126,7 @@ class CellComplex(Complex):
             source = source.uid
         if isinstance(target, Cell):
             target = target.uid
-        A, coldict = self.cell_adjacency_matrix(s=s, index=True)
+        A, coldict = self.adjacency_matrix(rank=2, index=True)
         G = nx.from_scipy_sparse_matrix(A)
         ckey = {v: k for k, v in coldict.items()}
         try:

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -22,7 +22,10 @@ from toponetx.classes.reportview import HyperEdgeView
 from toponetx.classes.simplex import Simplex
 from toponetx.classes.simplicial_complex import SimplicialComplex
 from toponetx.exception import TopoNetXError
-from toponetx.utils.structure import sparse_array_to_neighborhood_dict
+from toponetx.utils.structure import (
+    incidence_to_adjacency,
+    sparse_array_to_neighborhood_dict,
+)
 
 __all__ = ["CombinatorialComplex"]
 
@@ -1027,37 +1030,7 @@ class CombinatorialComplex(Complex):
             rank, to_rank, incidence_type=incidence_type, sparse=sparse, index=index
         )
 
-    @staticmethod
-    def _incidence_to_adjacency(B, s=1, weight=False):
-        """Get adjacency matrix from boolean incidence matrix for s-metrics.
-
-        Self loops are not supported.
-        The adjacency matrix will define an s-linegraph.
-
-        Parameters
-        ----------
-        B : scipy.sparse.csr.csr_matrix
-            incidence matrix of 0's and 1's
-        s : int, list, optional, default : 1
-            Minimum number of edges shared by neighbors with node.
-        weight : bool, dict optional, default=True
-            If False all nonzero entries are 1.
-            Otherwise, weight will be as in product.
-
-        Returns
-        -------
-        A : scipy.sparse.csr.csr_matrix
-        """
-        B = csr_matrix(B)
-        weight = False  # currently weighting is not supported
-
-        if weight is False:
-            A = B.dot(B.transpose())
-            A.setdiag(0)
-            A = (A >= s) * 1
-        return A
-
-    def adjacency_matrix(self, rank, via_rank, s=1, weight=False, index=False):
+    def adjacency_matrix(self, rank, via_rank, s=1, index=False):
         """Sparse weighted :term:`s-adjacency matrix`.
 
         Parameters
@@ -1068,9 +1041,6 @@ class CombinatorialComplex(Complex):
             Minimum number of edges shared by neighbors with node.
         index: boolean, optional, default: False
             If True, will return a rowdict of row to node uid
-        weight: bool, default=True
-            If False all nonzero entries are 1.
-            If True adjacency matrix will depend on weighted incidence matrix,
         index : book, default=False
             indicate weather to return the indices of the adjacency matrix.
 
@@ -1103,13 +1073,12 @@ class CombinatorialComplex(Complex):
             B = self.incidence_matrix(
                 rank, via_rank, incidence_type="up", sparse=True, index=index
             )
-        weight = False  # currently weighting is not supported
-        A = self._incidence_to_adjacency(B, s=s, weight=weight)
+        A = incidence_to_adjacency(B.T, s=s)
         if index:
             return A, row
         return A
 
-    def cell_adjacency_matrix(self, index=False, s=1, weight=False):
+    def cell_adjacency_matrix(self, index=False, s=1):
         """Compute the cell adjacency matrix.
 
         Parameters
@@ -1127,24 +1096,24 @@ class CombinatorialComplex(Complex):
         )
         if index:
 
-            A = self._incidence_to_adjacency(B[0].transpose(), s=s)
+            A = incidence_to_adjacency(B[0].transpose(), s=s)
 
             return A, B[2]
-        A = self._incidence_to_adjacency(B.transpose(), s=s)
+        A = incidence_to_adjacency(B.transpose(), s=s)
         return A
 
-    def node_adjacency_matrix(self, index=False, s=1, weight=False):
+    def node_adjacency_matrix(self, index=False, s=1):
         """Compute the node adjacency matrix."""
         B = self.incidence_matrix(
             rank=0, to_rank=None, incidence_type="up", index=index
         )
         if index:
-            A = self._incidence_to_adjacency(B[0], s=s)
+            A = incidence_to_adjacency(B[0], s=s)
             return A, B[1]
-        A = self._incidence_to_adjacency(B, s=s)
+        A = incidence_to_adjacency(B, s=s)
         return A
 
-    def coadjacency_matrix(self, rank, via_rank, s=1, weight=False, index=False):
+    def coadjacency_matrix(self, rank, via_rank, s=1, index=False):
         """Compute the coadjacency matrix.
 
         The sparse weighted :term:`s-coadjacency matrix`
@@ -1186,11 +1155,7 @@ class CombinatorialComplex(Complex):
             B = self.incidence_matrix(
                 rank, via_rank, incidence_type="down", sparse=True, index=index
             )
-        weight = False  # Currently weighting is not supported
-        if weight is False:
-            A = B.T.dot(B)
-            A.setdiag(0)
-            A = (A >= s) * 1
+        A = incidence_to_adjacency(B.T)
         if index:
             return A, col
         return A
@@ -1320,9 +1285,9 @@ class CombinatorialComplex(Complex):
         """
         B = self.incidence_matrix(rank=0, to_rank=None, incidence_type="up")
         if cells:
-            A = self._incidence_to_adjacency(B, s=s)
+            A = incidence_to_adjacency(B, s=s)
         else:
-            A = self._incidence_to_adjacency(B.transpose(), s=s)
+            A = incidence_to_adjacency(B.transpose(), s=s)
         G = nx.from_scipy_sparse_matrix(A)
         return nx.is_connected(G)
 

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -25,6 +25,8 @@ indices in S and T to other values.
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
+from scipy.sparse import csr_matrix
+
 
 def sparse_array_to_neighborhood_list(
     sparse_array, src_dict=None, dst_dict=None
@@ -99,3 +101,31 @@ def sparse_array_to_neighborhood_dict(
     return neighborhood_list_to_neighborhood_dict(
         sparse_array_to_neighborhood_list(sparse_array, src_dict, dst_dict)
     )
+
+
+def incidence_to_adjacency(B, s: int | None = None):
+    """Get adjacency matrix from boolean incidence matrix for s-metrics.
+
+    Self loops are not supported.
+    The adjacency matrix will define an s-linegraph.
+
+    Parameters
+    ----------
+    B : scipy.sparse.csr.csr_matrix
+        incidence matrix of 0's and 1's
+    s : int, list, optional, default : 1
+        Minimum number of edges shared by neighbors with node.
+
+    Returns
+    -------
+    A : scipy.sparse.csr.csr_matrix
+    """
+    B = csr_matrix(B)
+    B = abs(B)  # make sure the incidence matrix has only positive entries
+
+    A = B.T @ B
+    A.setdiag(0)
+    if s is not None:
+        A = (A >= s) * 1
+
+    return A


### PR DESCRIPTION
As we discussed, I moved `_incidence_to_adjacency` to the utility package. I also cleaned up duplicate adjacency methods in `CellComplex`, resulting in breaking changes.

- I don't think removing `s` breaks anything as it didn't work before
- However, removing `node_ajacency_matrix` and `cell_adjacency_matrix` will inevitably break something (they could be re-added as proxy methods for `adjacency_matrix` if you prefer)
- Also, we could think about changing the behavior of `adjacency_matrix`: Currently, the default is to use the lower adjacency. For rank 0, this does not really make sense. I'm not sure what I prefer:
  - changing it to default to upper for rank 0, but lower for other ranks is the way it is used most often, but then the default is not consistent over all ranks
  - changing it to always default to upper or lower would be consistent, but then it would need to be specified more often.