### PR TITLE
Cleanup examples in docstrings

### DIFF
--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -313,17 +313,16 @@ class CellComplex(Complex):
         Examples
         --------
         >>> cx = CellComplex()
-        >>> cx.add_cell ( (1,2,3,4),rank=2 )
-        >>> cx.add_cell ( (2,3,4,1),rank=2 )
-        >>> cx.add_cell ( (1,2,3,4),rank=2 )
-        >>> cx.add_cell ( (1,2,3,6),rank=2 )
-        >>> cx.add_cell ( (3,4,1,2),rank=2 )
-        >>> cx.add_cell ( (4,3,2,1),rank=2 )
-        >>> cx.add_cell ( (1,2,7,3),rank=2 )
-        >>> c1=Cell((1,2,3,4,5))
-        >>> cx.add_cell(c1,rank=2)
-        >>> d = cx._cell_equivalence_class()
-        >>> d
+        >>> cx.add_cell((1, 2, 3, 4), rank=2)
+        >>> cx.add_cell((2, 3, 4, 1), rank=2)
+        >>> cx.add_cell((1, 2, 3, 4), rank=2)
+        >>> cx.add_cell((1, 2, 3, 6), rank=2)
+        >>> cx.add_cell((3, 4, 1, 2), rank=2)
+        >>> cx.add_cell((4, 3, 2, 1), rank=2)
+        >>> cx.add_cell((1, 2, 7, 3), rank=2)
+        >>> c1 = Cell((1, 2, 3, 4, 5))
+        >>> cx.add_cell(c1, rank=2)
+        >>> cx._cell_equivalence_class()
         """
         equiv_classes = defaultdict(set)
         all_inserted_cells = set()
@@ -941,17 +940,15 @@ class CellComplex(Complex):
         --------
         >>> import networkx as nx
         >>> G = nx.path_graph(3)
-
-        >>> d={ ((1,2,3,4),0): { 'color':'red','attr2':1 },(1,2,4): {'color':'blue','attr2':3 } }
+        >>> d = {((1, 2, 3, 4), 0): {'color': 'red', 'attr2': 1}, (1, 2, 4): {'color': 'blue', 'attr2': 3 }}
         >>> CX = CellComplex(G)
-        >>> CX.add_cell([1,2,3,4], rank=2)
-        >>> CX.add_cell([1,2,3,4], rank=2)
-        >>> CX.add_cell([1,2,4], rank=2,)
-        >>> CX.add_cell([3,4,8], rank=2)
-        >>> CX.set_cell_attributes(d)
-        >>> cell_color=CX.get_cell_attributes('color',2)
-        >>> cell_color
-        '{((1, 2, 3, 4), 0): 'red', (1, 2, 4): 'blue'}
+        >>> CX.add_cell([1, 2, 3, 4], rank=2)
+        >>> CX.add_cell([1, 2, 3, 4], rank=2)
+        >>> CX.add_cell([1, 2, 4], rank=2,)
+        >>> CX.add_cell([3, 4, 8], rank=2)
+        >>> CX.set_cell_attributes(d, 2)
+        >>> CX.get_cell_attributes('color', 2)
+        {((1, 2, 3, 4), 0): 'red', (1, 2, 4): 'blue'}
         """
         if rank == 0:
             return nx.get_node_attributes(self._G, name)
@@ -1357,12 +1354,10 @@ class CellComplex(Complex):
         >>> CX.add_cell([3,4,5],rank=2)
         >>> L1_up = CX.up_laplacian_matrix(1)
 
-        Example2
-        --------
         >>> CX = CellComplex()
         >>> CX.add_cell([1,2,3],rank=2)
         >>> CX.add_cell([3,4,5],rank=2)
-        >>> index , L1_up = CX.up_laplacian_matrix(1,index=True)
+        >>> index, L1_up = CX.up_laplacian_matrix(1, index=True)
         >>> print(index)
         >>> print(L1_up)
         """
@@ -1513,8 +1508,8 @@ class CellComplex(Complex):
         Examples
         --------
         >>> CX = CellComplex()
-        >>> CX.add_cell([1,2,3],rank=2)
-        >>> CX.add_cell([1,4],rank=1)
+        >>> CX.add_cell([1, 2, 3], rank=2)
+        >>> CX.add_cell([1, 4], rank=1)
         >>> A = CX.cell_adjacency_matrix()
         """
         CX = self.to_combinatorial_complex()
@@ -2029,9 +2024,9 @@ class CellComplex(Complex):
         Parameters
         ----------
         source : cell.uid or cell
-            an cell in the cell complex
+            a cell in the cell complex
         target : cell.uid or cell
-            an cell in the cell complex
+            a cell in the cell complex
         s : int
             the number of intersections between pairwise consecutive cells
 
@@ -2071,14 +2066,13 @@ class CellComplex(Complex):
             return np.inf
 
     def from_networkx_graph(self, G):
-        """Add edges and nodes from a a graph G to self.
+        """Add edges and nodes from a graph G to self.
 
         Examples
         --------
         >>> CX = CellComplex()
         >>> CX.add_cells_from([[1,2,4],[1,2,7] ],rank=2)
-
-        >>> G= Graph()
+        >>> G = Graph()
         >>> G.add_edge(1,0)
         >>> G.add_edge(2,0)
         >>> G.add_edge(1,2)

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -75,7 +75,7 @@ class CombinatorialComplex(Complex):
     >>> CC.add_cell([1, 2, 3, 4], rank=2)
     >>> CC.add_cell([1, 2, 4], rank=2)
     >>> CC.add_cell([3, 4], rank=2)
-    >>> CC.add_cell([1,2,3,4,5,6,7], rank=3)
+    >>> CC.add_cell([1, 2, 3, 4, 5, 6, 7], rank=3)
     """
 
     def __init__(
@@ -1197,11 +1197,9 @@ class CombinatorialComplex(Complex):
         Examples
         --------
         >>> import trimesh
-        >>> mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]],
-                               faces=[[0, 1, 2]],
-                               process=False)
+        >>> mesh = trimesh.Trimesh(vertices=[[0, 0, 0], [0, 0, 1], [0, 1, 0]], faces=[[0, 1, 2]], process=False)
         >>> CC = CombinatorialComplex.from_trimesh(mesh)
-        >>> print(CC.nodes)
+        >>> CC.nodes
         """
         CC = CombinatorialComplex()
         return CC
@@ -1265,7 +1263,8 @@ class CombinatorialComplex(Complex):
         >>> G.add_edge(0, 1)
         >>> G.add_edge(0,4)
         >>> G.add_edge(0,7)
-        >>> CX = CombinatorialComplex.from_networkx_graph(G)
+        >>> CX = CombinatorialComplex()
+        >>> CX.from_networkx_graph(G)
         >>> CX.nodes
         RankedEntitySet(:Nodes,[0, 1, 4, 7],{'weight': 1.0})
         >>> CX.cells
@@ -1312,6 +1311,7 @@ class CombinatorialComplex(Complex):
         Examples
         --------
         >>> CC = CombinatorialComplex(cells=E)
+        >>> CC.is_connected()
         """
         B = self.incidence_matrix(rank=0, to_rank=None, incidence_type="up")
         if cells:

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -102,6 +102,7 @@ class SimplicialComplex(Complex):
     >>> SC = SimplicialComplex(simplices=G)
     >>> SC.add_simplex([1, 2, 3])
     >>> SC.simplices
+    SimplexView([(0,), (1,), (3,), (4,), (2,), (0, 1), (0, 3), (0, 4), (1, 4), (1, 2), (1, 3), (2, 3), (1, 2, 3)])
     """
 
     def __init__(self, simplices=None, name=None, mode="normal", **attr):
@@ -490,20 +491,6 @@ class SimplicialComplex(Complex):
             raise TypeError("input type must be iterable, or Simplex")
 
     def _remove_maximal_simplex(self, simplex):
-        """Remove maximal simplex from simplicial complex.
-
-        Note
-        -----
-        Only maximal simplices are allowed to be deleted. Otherwise raise ValueError
-
-        Examples
-        --------
-        >>> SC = SimplexView()
-        >>> SC.insert_simplex((1, 2, 3, 4), weight=1)
-        >>> c1=Simplex((1, 2, 3, 4, 5))
-        >>> SC.insert_simplex(c1)
-        >>> SC.remove_maximal_simplex((1, 2, 3, 4, 5))
-        """
         if isinstance(simplex, Iterable):
             if not isinstance(simplex, Simplex):
                 simplex_ = frozenset(
@@ -591,7 +578,19 @@ class SimplicialComplex(Complex):
         return face_set
 
     def remove_maximal_simplex(self, simplex):
-        """Remove maximal simplex from simplicial complex."""
+        """Remove maximal simplex from simplicial complex.
+
+        Note
+        -----
+        Only maximal simplices are allowed to be deleted. Otherwise, raise ValueError
+
+        Examples
+        --------
+        >>> SC = SimplicialComplex()
+        >>> SC.add_simplex((1, 2, 3, 4), weight=1)
+        >>> SC.add_simplex((1, 2, 3, 4, 5))
+        >>> SC.remove_maximal_simplex((1, 2, 3, 4, 5))
+        """
         self._remove_maximal_simplex(simplex)
 
     def add_node(self, node, **attr):
@@ -731,10 +730,9 @@ class SimplicialComplex(Complex):
         >>> SC.add_simplex([1, 2, 3, 4])
         >>> SC.add_simplex([1, 2, 4])
         >>> SC.add_simplex([3, 4, 8])
-        >>> d = {(1): 'red', (2): 'blue', (3): 'black'}
-        >>> SC.set_simplex_attributes(d, name='color')
-        >>> SC.get_node_attributes('color')
-        'blue'
+        >>> SC.set_simplex_attributes({1: "red", 2: "blue", 3: "black"}, name="color")
+        >>> SC.get_node_attributes("color")
+        {(1,): 'red', (2,): 'blue', (3,): 'black'}
         """
         return {tuple(n): self[n][name] for n in self.skeleton(0) if name in self[n]}
 
@@ -758,9 +756,10 @@ class SimplicialComplex(Complex):
         >>> SC.add_simplex([1, 2, 3, 4])
         >>> SC.add_simplex([1, 2, 4])
         >>> SC.add_simplex([3, 4, 8])
-        >>> d={(1,2):'red',(2,3):'blue',(3,4):"black"}
-        >>> SC.set_simplex_attributes(d,name='color')
-        >>> SC.get_simplex_attributes('color')
+        >>> d={(1, 2): "red", (2, 3): "blue", (3, 4): "black"}
+        >>> SC.set_simplex_attributes(d, name="color")
+        >>> SC.get_simplex_attributes("color")
+        {frozenset({1, 2}): 'red', frozenset({2, 3}): 'blue', frozenset({3, 4}): 'black'}
         """
         if rank is None:
             return {n: self[n][name] for n in self if name in self[n]}
@@ -1190,6 +1189,7 @@ class SimplicialComplex(Complex):
         >>> SC = SimplicialComplex([c1, c2, c3])
         >>> SC1 = SC.restrict_to_simplices([c1, (2, 4)])
         >>> SC1.simplices
+        SimplexView([(1,), (2,), (3,), (4,), (1, 2), (1, 3), (2, 3), (2, 4), (1, 2, 3)])
         """
         rns = []
         for cell in cell_set:
@@ -1222,7 +1222,9 @@ class SimplicialComplex(Complex):
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((1, 2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
-        >>> SC.restrict_to_nodes([1, 2, 3, 4])
+        >>> new_complex = SC.restrict_to_nodes([1, 2, 3, 4])
+        >>> new_complex.simplices
+        SimplexView([(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (1, 2, 3), (1, 2, 4)])
         """
         simplices = []
         node_set = set(node_set)
@@ -1241,17 +1243,19 @@ class SimplicialComplex(Complex):
 
         Examples
         --------
+        >>> c0 = Simplex((1, 2))
         >>> c1 = Simplex((1, 2, 3))
         >>> c2 = Simplex((1, 2, 4))
         >>> c3 = Simplex((2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
         >>> SC.get_all_maximal_simplices()
+        [(2, 5), (1, 2, 3), (1, 2, 4)]
         """
-        maxmimals = []
+        maximals = []
         for s in self:
             if self.is_maximal(s):
-                maxmimals.append(tuple(s))
-        return maxmimals
+                maximals.append(tuple(s))
+        return maximals
 
     @staticmethod
     def from_spharpy(mesh):
@@ -1511,6 +1515,7 @@ class SimplicialComplex(Complex):
         >>> hg = hnx.Hypergraph([[1, 2, 3, 4], [1, 2, 3]], static=True)
         >>> sc = SimplicialComplex.simplicial_closure_of_hypergraph(hg)
         >>> sc.simplices
+        SimplexView([(1,), (2,), (3,), (4,), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)])
         """
         edges = H.edges
         lst = []
@@ -1543,6 +1548,7 @@ class SimplicialComplex(Complex):
         >>> c3 = Simplex((2, 5))
         >>> SC = SimplicialComplex([c1, c2, c3])
         >>> SC.to_hypergraph()
+        Hypergraph({'e0': [1, 2], 'e1': [1, 3], 'e2': [1, 4], 'e3': [2, 3], 'e4': [2, 4], 'e5': [2, 5], 'e6': [1, 2, 3], 'e7': [1, 2, 4]},name=)
         """
         G = []
         for rank in range(1, self.dim + 1):


### PR DESCRIPTION
This cleans up some of the examples given in docstrings. In particular, some of the examples weren't executable at all, because non-existent functions were called.

Ref. #95 