### PR TITLE
Fix pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id : isort
         args : ["--profile=black", "--filter-files"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,13 +83,14 @@ addopts = "--capture=no"
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
-skip = [".gitignore", "__init__.py"]
+skip = [".gitignore", "__init__.py", ".venv"]
 
 [tool.flake8]
 application_import_names = "toponetx"
 docstring-convention = "numpy"
 import_order_style = "smarkets"
 max-line-length = 88
+extend-exclude = [".venv"]
 extend-ignore = ["E501", "F401", "E203"]
 per-file-ignores = [
     "*/__init__.py: F401,F403,D104"


### PR DESCRIPTION
The pre-commit hooks didn't work for me.

- old isort version could apparently not be installed (see also https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co)
- from .gitignore, using .venv for the virtual environment seems correct, but isort and flake8 considered source files of dependencies