### PR TITLE
Fix CellComplex.restrict_to_cells (see #40)

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -697,6 +697,29 @@ class TestCellComplex(unittest.TestCase):
         assert (4, 5) not in restricted.edges
         assert restricted.get_filtration("test") == {(1, 2, 3): 1, (1, 4): 0, 3: 1}
 
+    def test_restrict_to_cells(self):
+        """Test restricting a cell complex to a subset of cells and edges."""
+        CX = CellComplex([[1, 2, 3, 4], [3, 4, 5], [1, 2, 3, 6]])
+        CX.add_cell((1, 2, 3, 4), rank=2)
+        CX.set_filtration(
+            {(1, 2, 3, 4): 1, (1, 2): 2, (3, 5): 3, (4, 5): 4, (3, 4, 5): 5}, "test"
+        )
+        restricted = CX.restrict_to_cells(
+            {(1, 2, 3, 4), (3, 5), CX.cells.raw((1, 2, 3, 6))}
+        )
+        assert len(restricted.cells[(1, 2, 3, 4)]) == 2
+        assert (1, 2, 3, 4) in restricted.cells
+        assert (1, 2, 3, 6) in restricted.cells
+        assert (3, 4, 5) not in restricted.cells
+        assert (3, 5) in restricted.edges
+        assert (4, 5) not in restricted.edges
+        assert restricted.get_filtration("test") == {
+            ((1, 2, 3, 4), 0): 1,
+            ((1, 2, 3, 4), 1): 1,
+            (2, 1): 2,
+            (3, 5): 3,
+        }
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -4,6 +4,7 @@ Such as:
 HyperEdgeView, CellView, SimplexView.
 """
 from collections.abc import Hashable, Iterable
+from typing import List
 
 import numpy as np
 
@@ -80,6 +81,58 @@ class CellView:
                     return self._cells[cell][k].properties
                 else:
                     return [self._cells[cell][c].properties for c in self._cells[cell]]
+            else:
+                raise KeyError(f"cell {cell} is not in the cell dictionary")
+
+        else:
+            raise TypeError("Input must be a tuple, list or a cell.")
+
+    def raw(self, cell: tuple | list | Cell) -> Cell | List[Cell]:
+        """Indexes the raw cell objects analogous to the overall index of CellView.
+
+        Parameters
+        ----------
+        cell : tuple, list, or cell
+            The cell of interest.
+
+        Returns
+        -------
+        TYPE : Cell or list of Cells
+            The raw Cell objects.
+            If more than one cell with the same boundary exists, returns a list;
+            otherwise a single cell.
+
+        Raises
+        ------
+        KeyError
+            If the cell is not in the cell dictionary.
+        """
+        if isinstance(cell, Cell):
+
+            if cell.elements not in self._cells:
+                raise KeyError(f"cell {cell} is not in the cell dictionary")
+
+            # If there is only one cell with these elements, return its properties
+            elif len(self._cells[cell.elements]) == 1:
+                k = next(iter(self._cells[cell.elements].keys()))
+                return self._cells[cell.elements][k]
+
+            # If there are multiple cells with these elements, return the properties of all cells
+            else:
+                return [
+                    self._cells[cell.elements][c] for c in self._cells[cell.elements]
+                ]
+
+        # If a tuple or list is passed in, assume it represents a cell
+        elif isinstance(cell, tuple) or isinstance(cell, list):
+
+            cell = tuple(cell)
+            if cell in self._cells:
+                if len(self._cells[cell]) == 1:
+                    k = next(iter(self._cells[cell].keys()))
+                    return self._cells[cell][k]
+                else:
+                    return [self._cells[cell][c] for c in self._cells[cell]]
             else:
                 raise KeyError(f"cell {cell} is not in the cell dictionary")
 


### PR DESCRIPTION
restrict_to_cells discarded all attributes on cells, edges, and nodes.

I also added tests and updated docstrings.

As an aside, medium-term, we may want to check how we access and especially modify the Cell objects in CellView. Currently, most logic around that is in the CellComplex class, which is good to prevent users from modifying the underlying data structure, but makes it harder to understand how CellView works.