### PR TITLE
Adding lift from graph to Vietoris-Rips complex.

### DIFF
--- a/test/transform/test_graph_2_simplicial_complex.py
+++ b/test/transform/test_graph_2_simplicial_complex.py
@@ -7,7 +7,7 @@ import networkx as nx
 from toponetx.transform.graph_to_simplicial_complex import (
     graph_2_clique_complex,
     graph_2_neighbor_complex,
-    weighted_graph_2_Vietoris_Rips_complex
+    weighted_graph_2_vietoris_rips_complex,
 )
 
 
@@ -53,12 +53,11 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
 
         return
 
-    def test_weighted_graph_2_Vietoris_Rips_complex(self):
-        """Test weighted_graph_2_Vietoris_Rips_complex"""
+    def test_weighted_graph_2_vietoris_rips_complex(self):
+        """Test weighted_graph_2_vietoris_rips_complex."""
 
-        def generate_weighted_graph_for_Vietoris_Rips():
-            """Creates a weighted graph in networkx used to test the lift from
-            undirected weighted graphs to Vietoris-Rips simplicial complexes.
+        def generate_weighted_graph_for_vietoris_rips():
+            """Create a weighted graph in networkx to test the Vietoris-Rips simplicial complex lift.
 
             Returns
             -------
@@ -86,10 +85,12 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
             G.add_edge(6, 7, weight=4.0)
             return G
 
-        def generate_expected_simplices_for_Vietoris_Rips_complex(r):
-            """Generates a pair of lists of tuples containing the expected and non-expected simplices of the
+        def generate_expected_simplices_for_vietoris_rips_complex(r):
+            """Generate expected and unexpected simplices for the Vietoris-Rips complex of the test.
+
+            This function returns a pair of lists of tuples containing the expected and unexpected simplices of the
             Vietoris-Rips persistence diagram of the graph generated with the function
-            generate_weighted_graph_for_Vietoris_Rips depending on the radius r.
+            generate_weighted_graph_for_vietoris_rips depending on the radius r.
 
             Parameters
             ----------
@@ -97,54 +98,70 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
                 Radius of the Vietoris-Rips complex
 
             Returns
-            ----------
-            (list[tuple], list[tuple])
-                A tuple containing the lists of the expected simplices (first list) and non-expected elements (second
-                list) for the Vietoris-Rips complex.
+            -------
+            expected_and_unexpected_simplices: tuple[list[tuple], list[tuple]]
+                A tuple containing the lists of the expected and unexpected simplices (first and second lists,
+                respectively) for the Vietoris-Rips complex.
             """
             expected_vertices = [i for i in range(7)]
             expected_edges = []
-            non_expected_edges = []
+            unexpected_edges = []
             expected_triangles = []
-            non_expected_triangles = []
+            unexpected_triangles = []
             expected_tetrahedra = []
-            non_expected_tetrahedra = []
+            unexpected_tetrahedra = []
             # Now, for each radius, we include or exclude simplices depending on its value.
             # Radius 1
-            edges = expected_edges if 1 <= r else non_expected_edges
-            triangles = expected_triangles if 1 <= r else non_expected_triangles
-            tetrahedra = expected_tetrahedra if 1 <= r else non_expected_tetrahedra
+            edges = expected_edges if 1 <= r else unexpected_edges
+            triangles = expected_triangles if 1 <= r else unexpected_triangles
+            tetrahedra = expected_tetrahedra if 1 <= r else unexpected_tetrahedra
             edges.extend([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)])
             triangles.extend([(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)])
             tetrahedra.append((0, 1, 2, 3))
             # Radius 2
-            edges = expected_edges if 2 <= r else non_expected_edges
-            triangles = expected_triangles if 2 <= r else non_expected_triangles
+            edges = expected_edges if 2 <= r else unexpected_edges
+            triangles = expected_triangles if 2 <= r else unexpected_triangles
             edges.extend([(4, 5), (4, 6), (5, 6)])
             triangles.append((4, 5, 6))
             # Radius 3
-            edges = expected_edges if 3 <= r else non_expected_edges
+            edges = expected_edges if 3 <= r else unexpected_edges
             edges.append((3, 4))
             # Radius 4
-            edges = expected_edges if 4 <= r else non_expected_edges
-            triangles = expected_triangles if 4 <= r else non_expected_triangles
-            tetrahedra = expected_tetrahedra if 4 <= r else non_expected_tetrahedra
+            edges = expected_edges if 4 <= r else unexpected_edges
+            triangles = expected_triangles if 4 <= r else unexpected_triangles
+            tetrahedra = expected_tetrahedra if 4 <= r else unexpected_tetrahedra
             edges.extend([(4, 7), (5, 7), (6, 7)])
             triangles.extend([(4, 5, 7), (4, 6, 7), (5, 6, 7)])
             tetrahedra.append((4, 5, 6, 7))
-            expected_simplices = expected_vertices + expected_edges + expected_triangles + expected_tetrahedra
-            non_expected_simplices = non_expected_edges + non_expected_triangles + non_expected_tetrahedra
-            return expected_simplices, non_expected_simplices
+            expected_simplices = (
+                expected_vertices
+                + expected_edges
+                + expected_triangles
+                + expected_tetrahedra
+            )
+            unexpected_simplices = (
+                unexpected_edges + unexpected_triangles + unexpected_tetrahedra
+            )
+            return expected_simplices, unexpected_simplices
 
-        radii_to_check = [0, 1, 2, 3, 4] # Four possible different configurations for the Vietoris-Rips complex of the
+        radii_to_check = [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]  # Four possible different configurations for the Vietoris-Rips complex of the
         # associated graph.
-        weighted_graph = generate_weighted_graph_for_Vietoris_Rips()
+        weighted_graph = generate_weighted_graph_for_vietoris_rips()
         for radius in radii_to_check:
-            sc = weighted_graph_2_Vietoris_Rips_complex(weighted_graph, radius)
-            expected_simplices, non_expected_simplices = generate_expected_simplices_for_Vietoris_Rips_complex(radius)
+            sc = weighted_graph_2_vietoris_rips_complex(weighted_graph, radius)
+            (
+                expected_simplices,
+                unexpected_simplices,
+            ) = generate_expected_simplices_for_vietoris_rips_complex(radius)
             for simplex in expected_simplices:
                 assert simplex in sc
-            for simplex in non_expected_simplices:
+            for simplex in unexpected_simplices:
                 assert simplex not in sc
 
 

--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -1,21 +1,20 @@
 """Test graph to simplicial complex transformation."""
 
-import unittest
 
 import networkx as nx
 
 from toponetx.transform.graph_to_simplicial_complex import (
-    graph_2_clique_complex,
-    graph_2_neighbor_complex,
-    weighted_graph_2_vietoris_rips_complex,
+    graph_to_clique_complex,
+    graph_to_neighbor_complex,
+    weighted_graph_to_vietoris_rips_complex,
 )
 
 
-class TestGraphToSimplicialComplex(unittest.TestCase):
+class TestGraphToSimplicialComplex:
     """Test graph to simplicial complex transformation."""
 
-    def test_graph_2_neighbor_complex(self):
-        """Test graph_2_neighbor_complex."""
+    def test_graph_to_neighbor_complex(self):
+        """Test graph_to_neighbor_complex."""
         G = nx.Graph()
 
         G.add_edge(0, 1)
@@ -23,14 +22,14 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
         G.add_edge(2, 3)
         G.add_edge(3, 0)
 
-        sc = graph_2_neighbor_complex(G)
+        sc = graph_to_neighbor_complex(G)
 
         assert sc.dim == 2
         assert (0, 1) in sc
         assert (0, 2) in sc
 
-    def test_graph_2_clique_complex(self):
-        """Test graph_2_clique_complex."""
+    def test_graph_to_clique_complex(self):
+        """Test graph_to_clique_complex."""
         G = nx.Graph()
 
         G.add_edge(0, 1)
@@ -39,13 +38,13 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
         G.add_edge(2, 3)
         G.add_edge(3, 0)
 
-        sc = graph_2_clique_complex(G)
+        sc = graph_to_clique_complex(G)
 
         assert sc.dim == 2
         assert (0, 2, 3) in sc
         assert (0, 1, 2) in sc
 
-        sc = graph_2_clique_complex(G, max_dim=2)
+        sc = graph_to_clique_complex(G, max_dim=2)
 
         assert sc.dim == 1
         assert (0, 2, 3) not in sc
@@ -53,8 +52,8 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
 
         return
 
-    def test_weighted_graph_2_vietoris_rips_complex(self):
-        """Test weighted_graph_2_vietoris_rips_complex."""
+    def test_weighted_graph_to_vietoris_rips_complex(self):
+        """Test weighted_graph_to_vietoris_rips_complex."""
 
         def generate_weighted_graph_for_vietoris_rips():
             """Create a weighted graph in networkx to test the Vietoris-Rips simplicial complex lift.
@@ -154,7 +153,7 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
         # associated graph.
         weighted_graph = generate_weighted_graph_for_vietoris_rips()
         for radius in radii_to_check:
-            sc = weighted_graph_2_vietoris_rips_complex(weighted_graph, radius)
+            sc = weighted_graph_to_vietoris_rips_complex(weighted_graph, radius)
             (
                 expected_simplices,
                 unexpected_simplices,
@@ -163,7 +162,3 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
                 assert simplex in sc
             for simplex in unexpected_simplices:
                 assert simplex not in sc
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -7,7 +7,7 @@ import networkx as nx
 from toponetx.transform.graph_to_simplicial_complex import (
     graph_2_clique_complex,
     graph_2_neighbor_complex,
-    weighted_graph_to_Vietoris_Rips_complex
+    weighted_graph_2_Vietoris_Rips_complex
 )
 
 
@@ -53,8 +53,8 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
 
         return
 
-    def test_weighted_graph_to_Vietoris_Rips_complex(self):
-        """Test weighted_graph_to_Vietoris_Rips_complex"""
+    def test_weighted_graph_2_Vietoris_Rips_complex(self):
+        """Test weighted_graph_2_Vietoris_Rips_complex"""
 
         def generate_weighted_graph_for_Vietoris_Rips():
             """Creates a weighted graph in networkx used to test the lift from
@@ -140,7 +140,7 @@ class TestGraphToSimplicialComplex(unittest.TestCase):
         # associated graph.
         weighted_graph = generate_weighted_graph_for_Vietoris_Rips()
         for radius in radii_to_check:
-            sc = weighted_graph_to_Vietoris_Rips_complex(weighted_graph, radius)
+            sc = weighted_graph_2_Vietoris_Rips_complex(weighted_graph, radius)
             expected_simplices, non_expected_simplices = generate_expected_simplices_for_Vietoris_Rips_complex(radius)
             for simplex in expected_simplices:
                 assert simplex in sc

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -16,9 +16,9 @@ from .classes.simplex import Simplex
 from .classes.simplicial_complex import SimplicialComplex
 from .datasets.mesh import stanford_bunny
 from .transform.graph_to_simplicial_complex import (
-    graph_2_clique_complex,
-    graph_2_neighbor_complex,
-    weighted_graph_2_vietoris_rips_complex,
+    graph_to_clique_complex,
+    graph_to_neighbor_complex,
+    weighted_graph_to_vietoris_rips_complex,
 )
 from .utils.structure import (
     neighborhood_list_to_neighborhood_dict,

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -17,9 +17,8 @@ from .classes.simplicial_complex import SimplicialComplex
 from .datasets.mesh import stanford_bunny
 from .transform.graph_to_simplicial_complex import (
     graph_2_clique_complex,
-    vietoris-rips-lifting,
     graph_2_neighbor_complex,
-  weighted_graph_2_Vietoris_Rips_complex
+    weighted_graph_2_vietoris_rips_complex,
 )
 from .utils.structure import (
     neighborhood_list_to_neighborhood_dict,

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -23,7 +23,7 @@ from .datasets.mesh import stanford_bunny
 from .transform.graph_to_simplicial_complex import (
     graph_2_neighbor_complex,
     graph_2_clique_complex,
-    weighted_graph_to_Vietoris_Rips_complex
+    weighted_graph_2_Vietoris_Rips_complex
 )
 
 from .utils.structure import (

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -23,6 +23,7 @@ from .datasets.mesh import stanford_bunny
 from .transform.graph_to_simplicial_complex import (
     graph_2_neighbor_complex,
     graph_2_clique_complex,
+    weighted_graph_to_Vietoris_Rips_complex
 )
 
 from .utils.structure import (

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -23,7 +23,7 @@ from .datasets.mesh import stanford_bunny
 from .transform.graph_to_simplicial_complex import (
     graph_2_neighbor_complex,
     graph_2_clique_complex,
-    weighted_graph_2_Vietoris_Rips_complex
+    weighted_graph_2_vietoris_rips_complex,
 )
 
 from .utils.structure import (

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -3,7 +3,7 @@
 __all__ = [
     "graph_2_clique_complex",
     "graph_2_neighbor_complex",
-    "weighted_graph_to_Vietoris_Rips_complex"
+    "weighted_graph_2_Vietoris_Rips_complex"
 ]
 
 import itertools
@@ -64,7 +64,7 @@ def graph_2_clique_complex(G, max_dim=None):
     return SimplicialComplex(list(lst))
 
 
-def weighted_graph_to_Vietoris_Rips_complex(G, r, max_dim=None):
+def weighted_graph_2_Vietoris_Rips_complex(G, r, max_dim=None):
     """Get the Vietoris-Rips complex of radius r of a weighted undirected graph. The Vietoris-Rips complex of radius
     r is the clique complex given by the cliques of G whose nodes have pairwise distances less or equal than r. All
     vertices are added to the Vietoris-Rips complex regardless the radius introduced. If G is a clique weighted by a

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -3,8 +3,10 @@
 __all__ = [
     "graph_2_clique_complex",
     "graph_2_neighbor_complex",
+    "weighted_graph_to_Vietoris_Rips_complex"
 ]
 
+import itertools
 
 import networkx as nx
 
@@ -60,3 +62,40 @@ def graph_2_clique_complex(G, max_dim=None):
 
     lst = filter(lambda face: len(face) <= max_dim, nx.enumerate_all_cliques(G))
     return SimplicialComplex(list(lst))
+
+
+def weighted_graph_to_Vietoris_Rips_complex(G, r, max_dim=None):
+    """Get the Vietoris-Rips complex of radius r of a weighted undirected graph. The Vietoris-Rips complex of radius
+    r is the clique complex given by the cliques of G whose nodes have pairwise distances less or equal than r. All
+    vertices are added to the Vietoris-Rips complex regardless the radius introduced. If G is a clique weighted by a
+    dissimilarity function d that satisfies max_v d(v, v) <= min d(u,v) for u != v, and r >= d(v, v) for all nodes v,
+    then the Vietoris-Rips complex of radius r is the usual Vietoris-Rips abstract simplicial complex of radius r for
+    point clouds with dissimilarities.
+
+    Parameters
+    ----------
+    G : networkx graph
+        Weighted undirected input graph. The weights of the edges must be in the attribute 'weight'.
+    r : float
+        The radius for the Vietoris-Rips simplicial complex computation.
+    max_dim : int, optional
+        The max dimension of the cliques in
+        the output clique complex.
+        The default is None indicate max dimension.
+
+    Returns
+    -------
+    SimplicialComplex
+        The Vietoris-Rips simplicial complex of dimension max_dim of the graph G.
+        """
+
+    def is_in_VR_complex(clique):
+        # Check if all edge weights are less or equal than r
+        edges = itertools.combinations(clique, 2)
+        edge_weights_lower_than_r = all(G[u][v]['weight'] <= r for u, v in edges)
+        return edge_weights_lower_than_r
+
+    all_cliques = nx.enumerate_all_cliques(G)
+    possible_cliques = all_cliques if max_dim is None else filter(lambda face: len(face) <= max_dim, all_cliques)
+    vr_cliques = filter(is_in_VR_complex, possible_cliques)
+    return SimplicialComplex(list(vr_cliques))

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -3,7 +3,7 @@
 __all__ = [
     "graph_2_clique_complex",
     "graph_2_neighbor_complex",
-    "weighted_graph_2_Vietoris_Rips_complex"
+    "weighted_graph_2_vietoris_rips_complex",
 ]
 
 import itertools
@@ -64,8 +64,10 @@ def graph_2_clique_complex(G, max_dim=None):
     return SimplicialComplex(list(lst))
 
 
-def weighted_graph_2_Vietoris_Rips_complex(G, r, max_dim=None):
-    """Get the Vietoris-Rips complex of radius r of a weighted undirected graph. The Vietoris-Rips complex of radius
+def weighted_graph_2_vietoris_rips_complex(G, r, max_dim=None):
+    """Get the Vietoris-Rips complex of radius r of a weighted undirected graph.
+
+    The Vietoris-Rips complex of radius
     r is the clique complex given by the cliques of G whose nodes have pairwise distances less or equal than r. All
     vertices are added to the Vietoris-Rips complex regardless the radius introduced. If G is a clique weighted by a
     dissimilarity function d that satisfies max_v d(v, v) <= min d(u,v) for u != v, and r >= d(v, v) for all nodes v,
@@ -87,15 +89,18 @@ def weighted_graph_2_Vietoris_Rips_complex(G, r, max_dim=None):
     -------
     SimplicialComplex
         The Vietoris-Rips simplicial complex of dimension max_dim of the graph G.
-        """
+    """
 
-    def is_in_VR_complex(clique):
-        # Check if all edge weights are less or equal than r
+    def is_in_vr_complex(clique):
         edges = itertools.combinations(clique, 2)
-        edge_weights_lower_than_r = all(G[u][v]['weight'] <= r for u, v in edges)
+        edge_weights_lower_than_r = all(G[u][v]["weight"] <= r for u, v in edges)
         return edge_weights_lower_than_r
 
     all_cliques = nx.enumerate_all_cliques(G)
-    possible_cliques = all_cliques if max_dim is None else filter(lambda face: len(face) <= max_dim, all_cliques)
-    vr_cliques = filter(is_in_VR_complex, possible_cliques)
+    possible_cliques = (
+        all_cliques
+        if max_dim is None
+        else filter(lambda face: len(face) <= max_dim, all_cliques)
+    )
+    vr_cliques = filter(is_in_vr_complex, possible_cliques)
     return SimplicialComplex(list(vr_cliques))

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -1,9 +1,9 @@
 """Methods to lift a graph to a simplicial complex."""
 
 __all__ = [
-    "graph_2_clique_complex",
-    "graph_2_neighbor_complex",
-    "weighted_graph_2_vietoris_rips_complex",
+    "graph_to_clique_complex",
+    "graph_to_neighbor_complex",
+    "weighted_graph_to_vietoris_rips_complex",
 ]
 
 import itertools
@@ -13,7 +13,7 @@ import networkx as nx
 from toponetx import SimplicialComplex
 
 
-def graph_2_neighbor_complex(G):
+def graph_to_neighbor_complex(G):
     """Get the neighbor complex of a graph.
 
     Parameters
@@ -39,7 +39,7 @@ def graph_2_neighbor_complex(G):
     return SimplicialComplex(neighbors)
 
 
-def graph_2_clique_complex(G, max_dim=None):
+def graph_to_clique_complex(G, max_dim=None):
     """Get the clique complex of a graph.
 
     Parameters
@@ -64,7 +64,7 @@ def graph_2_clique_complex(G, max_dim=None):
     return SimplicialComplex(list(lst))
 
 
-def weighted_graph_2_vietoris_rips_complex(G, r, max_dim=None):
+def weighted_graph_to_vietoris_rips_complex(G, r, max_dim=None):
     """Get the Vietoris-Rips complex of radius r of a weighted undirected graph.
 
     The Vietoris-Rips complex of radius


### PR DESCRIPTION
This commit creates a method to convert a graph into a Vietoris-Rips clique complex. It mimics the behaviour of the previous method `graph_2_clique_complex` but only adds cliques whose nodes have pairwise distances less than a radius parameter of the function. Unit tests added.