### PR TITLE
Remove `Complex._clear_cache`

### DIFF
--- a/test/classes/test_complex.py
+++ b/test/classes/test_complex.py
@@ -130,19 +130,6 @@ class TestComplex(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             complex_obj.coadjacency_matrix()
 
-    def test_clear_cache(self):
-        """Test the _clear_cache method."""
-        complex_obj = self.ConcreteComplex()
-
-        with self.assertRaises(AttributeError):
-            complex_obj.cache  # Cache attribute should not exist initially
-
-        complex_obj._clear_cache()
-
-        self.assertEqual(
-            complex_obj.cache, {}
-        )  # Cache attribute should be an empty dictionary
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -76,10 +76,6 @@ class Complex:
         """Return number of nodes."""
         pass
 
-    def _clear_cache(self):
-        """Clear cache."""
-        self.cache = {}
-
     @abc.abstractmethod
     def clone(self):
         """Clone complex."""


### PR DESCRIPTION
This method is not used anywhere, and it is not clear why a complex inherently needs a cache anyway.