### PR TITLE
Unify `shape` properties of complexes

### DIFF
--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -28,14 +28,11 @@ class TestSimplicialComplex(unittest.TestCase):
 
     def test_shape_property(self):
         """Test shape property."""
-        # Test the shape property of the SimplicialComplex class
         sc = SimplicialComplex([[1, 2, 3], [2, 3, 4], [0, 1]])
-        self.assertEqual(sc.shape, [5, 6, 2])
+        self.assertEqual(sc.shape, (5, 6, 2))
 
-    def test_shape_empty(self):
-        """Test shape property when Simplicial Complex is Empty."""
         sc = SimplicialComplex()
-        self.assertEqual(sc.shape, None)
+        self.assertEqual(sc.shape, tuple())
 
     def test_dim_property(self):
         """Test dim property."""

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -309,7 +309,7 @@ class CombinatorialComplex(Complex):
         return self._complex_set.hyperedge_dict
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         """Return shape.
 
         This is:
@@ -317,7 +317,7 @@ class CombinatorialComplex(Complex):
 
         Returns
         -------
-        tuple
+        tuple of ints
         """
         return self._complex_set.shape
 

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -52,8 +52,14 @@ class Complex:
 
     @property
     @abc.abstractmethod
-    def shape(self) -> tuple:
-        """Return number of cells for each rank."""
+    def shape(self) -> tuple[int, ...]:
+        """Return number of cells for each rank.
+
+        Returns
+        -------
+        tuple of ints
+            The number of elements for each rank. If the complex is empty, an empty tuple is returned.
+        """
         pass
 
     @abc.abstractmethod

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -243,12 +243,9 @@ class HyperEdgeView:
         return self.hyperedge_dict[rank][hyperedge_]
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         """Compute shape."""
-        if len(self.hyperedge_dict) == 0:
-            print("Complex is empty.")
-        else:
-            return [len(self.hyperedge_dict[i]) for i in self.allranks]
+        return tuple(len(self.hyperedge_dict[i]) for i in self.allranks)
 
     def __len__(self):
         """Compute number of nodes."""
@@ -521,18 +518,15 @@ class SimplexView:
                 return self.faces_dict[0][frozenset({simplex})]
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         """Return the number of simplices in each dimension.
 
         Returns
         -------
-        list
-            A list of integers representing the number of simplices in each dimension.
+        tuple of ints
+            A tuple of integers representing the number of simplices in each dimension.
         """
-        if len(self.faces_dict) == 0:
-            print("Complex is empty.")
-        else:
-            return [len(self.faces_dict[i]) for i in range(len(self.faces_dict))]
+        return tuple(len(self.faces_dict[i]) for i in range(len(self.faces_dict)))
 
     def __len__(self):
         """Return the number of simplices in the SimplexView instance."""

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -133,22 +133,19 @@ class SimplicialComplex(Complex):
                 self._add_simplices_from(simplices)
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, ...]:
         """Shape of simplicial complex.
 
         (number of simplices[i], for i in range(0,dim(Sc))  )
 
         Returns
         -------
-        tuple
+        tuple of ints
         """
-        if len(self._simplex_set.faces_dict) == 0:
-            print("Simplicial Complex is empty.")
-        else:
-            return [
-                len(self._simplex_set.faces_dict[i])
-                for i in range(len(self._simplex_set.faces_dict))
-            ]
+        return tuple(
+            len(self._simplex_set.faces_dict[i])
+            for i in range(len(self._simplex_set.faces_dict))
+        )
 
     @property
     def dim(self) -> int:


### PR DESCRIPTION
The `shape` property now always is a tuple and may be empty for empty complexes.