### PR TITLE
Remove `SimplicialComplex.__setitem__` method

### DIFF
--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -127,8 +127,8 @@ class TestSimplicialComplex:
         with pytest.raises(KeyError):
             SC[(1, 2, 3, 4, 5)]["heat"]
 
-    def test_setitem__(self):
-        """Test __getitem__ and __setitem__ methods."""
+    def test_setting_simplex_attributes(self):
+        """Test setting simplex attributes through a `SimplicialComplex` object."""
         G = nx.Graph()
         G.add_edge(0, 1)
         G.add_edge(2, 5)

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -248,20 +248,6 @@ class SimplicialComplex(Complex):
         else:
             raise KeyError("simplex is not in the simplicial complex")
 
-    def __setitem__(self, simplex, **attr):
-        """Set attributes to a simplex."""
-        if isinstance(simplex, Simplex):
-            if simplex.nodes in self.faces_dict[len(simplex) - 1]:
-                self.faces_dict[len(simplex) - 1].update(attr)
-        elif isinstance(simplex, Iterable):
-            simplex = frozenset(simplex)
-            self.faces_dict[len(simplex) - 1].update(attr)
-        elif isinstance(simplex, Hashable):
-            if frozenset({simplex}) in self:
-                self.faces_dict[0].update(attr)
-        else:
-            raise TypeError("Input simplex must be Simplex, Iterable or Hashable.")
-
     def __iter__(self):
         """Iterate over all faces of the simplicial complex.
 


### PR DESCRIPTION
This method doesn't work. Setting simplex attributes doesn't go through `SimplicialComplex.__setitem__` but through `SimplicialComplex.__getitem__` and `SimplexView.__getitem__`.