### PR TITLE
Fixing little bug in CombinatorialComplex class

### DIFF
--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -142,7 +142,7 @@ class CombinatorialComplex(Complex):
                     u, v = edge
                     self.add_cell([u, v], 1, **cells.get_edge_data(u, v))
 
-    def _incidence_matrix_helper(self, children, uidset, sparse=True, index=False):
+    def _ce_matrix_helper(self, children, uidset, sparse=True, index=False):
         """Help compute the incidence matrix."""
         from collections import OrderedDict
         from operator import itemgetter
@@ -1164,7 +1164,7 @@ class CombinatorialComplex(Complex):
             B = self.incidence_matrix(
                 rank, via_rank, incidence_type="down", sparse=True, index=index
             )
-        A = incidence_to_adjacency(B.T)
+        A = incidence_to_adjacency(B)
         if index:
             return A, col
         return A

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -142,7 +142,7 @@ class CombinatorialComplex(Complex):
                     u, v = edge
                     self.add_cell([u, v], 1, **cells.get_edge_data(u, v))
 
-    def _ce_matrix_helper(self, children, uidset, sparse=True, index=False):
+    def _incidence_matrix_helper(self, children, uidset, sparse=True, index=False):
         """Help compute the incidence matrix."""
         from collections import OrderedDict
         from operator import itemgetter

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -253,10 +253,10 @@ class CombinatorialComplex(Complex):
         if to_rank is None:
             if incidence_type == "up":
                 children = self.skeleton(rank)
-                uidset = self.skeleton(rank + 1, level="upper")
+                uidset = self.skeleton(rank + 1)
             elif incidence_type == "down":
                 uidset = self.skeleton(rank)
-                children = self.skeleton(rank - 1, level="lower")
+                children = self.skeleton(rank - 1)
             raise TopoNetXError("incidence_type must be 'up' or 'down' ")
         else:
             assert (


### PR DESCRIPTION
_incidence_matrix method calling self.skeleton with an extra argument level, which is not needed nor defined in the CC class.
coadjacency_matrix method sending to incidence_to_adjacency method the incidence matrix transpose.