### PR TITLE
Rename transform methods from graphs to simplicial complexes

### DIFF
--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -6,11 +6,50 @@ import pytest
 from toponetx.transform.graph_to_simplicial_complex import (
     graph_2_clique_complex,
     graph_2_neighbor_complex,
+    graph_to_clique_complex,
+    graph_to_neighbor_complex,
 )
 
 
 class TestGraphToSimplicialComplex:
     """Test graph to simplicial complex transformation."""
+
+    def test_graph_to_neighbor_complex(self):
+        """Test graph_2_neighbor_complex."""
+        G = nx.Graph()
+
+        G.add_edge(0, 1)
+        G.add_edge(1, 2)
+        G.add_edge(2, 3)
+        G.add_edge(3, 0)
+
+        sc = graph_to_neighbor_complex(G)
+
+        assert sc.dim == 2
+        assert (0, 1) in sc
+        assert (0, 2) in sc
+
+    def test_graph_to_clique_complex(self):
+        """Test graph_2_clique_complex."""
+        G = nx.Graph()
+
+        G.add_edge(0, 1)
+        G.add_edge(1, 2)
+        G.add_edge(2, 0)
+        G.add_edge(2, 3)
+        G.add_edge(3, 0)
+
+        sc = graph_to_clique_complex(G)
+
+        assert sc.dim == 2
+        assert (0, 2, 3) in sc
+        assert (0, 1, 2) in sc
+
+        sc = graph_to_clique_complex(G, max_dim=2)
+
+        assert sc.dim == 1
+        assert (0, 2, 3) not in sc
+        assert (0, 1, 2) not in sc
 
     def test_graph_2_neighbor_complex(self):
         """Test graph_2_neighbor_complex."""
@@ -21,7 +60,8 @@ class TestGraphToSimplicialComplex:
         G.add_edge(2, 3)
         G.add_edge(3, 0)
 
-        sc = graph_2_neighbor_complex(G)
+        with pytest.deprecated_call():
+            sc = graph_2_neighbor_complex(G)
 
         assert sc.dim == 2
         assert (0, 1) in sc
@@ -37,13 +77,15 @@ class TestGraphToSimplicialComplex:
         G.add_edge(2, 3)
         G.add_edge(3, 0)
 
-        sc = graph_2_clique_complex(G)
+        with pytest.deprecated_call():
+            sc = graph_2_clique_complex(G)
 
         assert sc.dim == 2
         assert (0, 2, 3) in sc
         assert (0, 1, 2) in sc
 
-        sc = graph_2_clique_complex(G, max_dim=2)
+        with pytest.deprecated_call():
+            sc = graph_2_clique_complex(G, max_dim=2)
 
         assert sc.dim == 1
         assert (0, 2, 3) not in sc

--- a/toponetx/__init__.py
+++ b/toponetx/__init__.py
@@ -20,6 +20,8 @@ from .transform.graph_to_cell_complex import homology_cycle_cell_complex
 from .transform.graph_to_simplicial_complex import (
     graph_2_clique_complex,
     graph_2_neighbor_complex,
+    graph_to_clique_complex,
+    graph_to_neighbor_complex,
 )
 from .utils.structure import (
     neighborhood_list_to_neighborhood_dict,

--- a/toponetx/datasets/graph.py
+++ b/toponetx/datasets/graph.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from toponetx import CellComplex, SimplicialComplex
 from toponetx.algorithms.spectrum import hodge_laplacian_eigenvectors
-from toponetx.transform.graph_to_simplicial_complex import graph_2_clique_complex
+from toponetx.transform.graph_to_simplicial_complex import graph_to_clique_complex
 
 __all__ = ["karate_club"]
 
@@ -34,7 +34,7 @@ def karate_club(
     Parameters
     ----------
     complex_type : {'simplicial','cell'}, default='simplicial'
-        The type of complex to loaded.
+        The type of complex to load.
     feat_dim : int, default=2
         The number of eigenvectors to be attached to the simplices/cells
         of the output complex.
@@ -76,7 +76,7 @@ def karate_club(
     """
     if complex_type == "simplicial":
         g = nx.karate_club_graph()
-        sc = graph_2_clique_complex(g)
+        sc = graph_to_clique_complex(g)
 
         _, nodes_feat = hodge_laplacian_eigenvectors(
             sc.hodge_laplacian_matrix(0), feat_dim

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -1,17 +1,18 @@
 """Methods to lift a graph to a simplicial complex."""
 
-__all__ = [
-    "graph_2_clique_complex",
-    "graph_2_neighbor_complex",
-]
-
+from warnings import warn
 
 import networkx as nx
 
-from toponetx import SimplicialComplex
+from toponetx.classes.simplicial_complex import SimplicialComplex
+
+__all__ = [
+    "graph_to_clique_complex",
+    "graph_to_neighbor_complex",
+]
 
 
-def graph_2_neighbor_complex(G):
+def graph_to_neighbor_complex(G: nx.Graph) -> SimplicialComplex:
     """Get the neighbor complex of a graph.
 
     Parameters
@@ -28,16 +29,17 @@ def graph_2_neighbor_complex(G):
     -----
     This type of simplicial complexes can have very large dimension ( dimension = max_i(len (G.neighbors(i))) )
     and it is a function of the distribution of the valency of the graph.
-
     """
-    neighbors = []
-    for i in G.nodes():
-        N = list(G.neighbors(i)) + [i]  # each simplex is the node and its n-hop nbhd
-        neighbors.append(N)
-    return SimplicialComplex(neighbors)
+    simplices = []
+    for node in G:
+        # each simplex is the node and its n-hop neighbors
+        simplices.append(list(G.neighbors(node)) + [node])
+    return SimplicialComplex(simplices)
 
 
-def graph_2_clique_complex(G, max_dim=None):
+def graph_to_clique_complex(
+    G: nx.Graph, max_dim: int | None = None
+) -> SimplicialComplex:
     """Get the clique complex of a graph.
 
     Parameters
@@ -54,9 +56,28 @@ def graph_2_clique_complex(G, max_dim=None):
     SimplicialComplex
         The clique simplicial complex of dimension dim of the graph G.
     """
-    if max_dim is None:
-        lst = nx.enumerate_all_cliques(G)
-        return SimplicialComplex(list(lst))
+    cliques = nx.enumerate_all_cliques(G)
+    if max_dim is not None:
+        cliques = filter(lambda clique: len(clique) <= max_dim, cliques)
 
-    lst = filter(lambda face: len(face) <= max_dim, nx.enumerate_all_cliques(G))
-    return SimplicialComplex(list(lst))
+    return SimplicialComplex(cliques)
+
+
+def graph_2_neighbor_complex(G) -> SimplicialComplex:
+    warn(
+        "`graph_2_neighbor_complex` is deprecated and will be removed in a future version, use `graph_to_neighbor_complex` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return graph_to_neighbor_complex(G)
+
+
+def graph_2_clique_complex(
+    G: nx.Graph, max_dim: int | None = None
+) -> SimplicialComplex:
+    warn(
+        "`graph_2_clique_complex` is deprecated and will be removed in a future version, use `graph_to_clique_complex` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return graph_to_clique_complex(G, max_dim)


### PR DESCRIPTION
Old method names are still available but raise a deprecation warning.