### PR TITLE
Extract name attribute into `Complex` superclass

### DIFF
--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -131,9 +131,7 @@ class CellComplex(Complex):
     """
 
     def __init__(self, cells=None, name: str = "", regular=True, **kwargs) -> None:
-        super().__init__(**kwargs)
-
-        self.name = name
+        super().__init__(name, **kwargs)
 
         self._regular = regular
         self._G = Graph()

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -90,9 +90,7 @@ class CombinatorialComplex(Complex):
         graph_based: bool = False,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
-
-        self.name = name
+        super().__init__(name, **kwargs)
 
         self.graph_based = graph_based  # rank 1 edges have cardinality equals to 1
 
@@ -105,7 +103,6 @@ class CombinatorialComplex(Complex):
         self._aux_complex = SimplicialComplex()
 
         self._complex_set = HyperEdgeView()
-        self.complex = dict()  # dictionary for combinatorial complex attributes
 
         if cells is not None:
             if not isinstance(cells, Iterable):

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -128,6 +128,8 @@ class Complex(abc.ABC):
 
     Parameters
     ----------
+    name : str, optional
+        Optional name for the complex.
     kwargs : keyword arguments, optional
         Attributes to add to the complex as key=value pairs.
 
@@ -139,7 +141,8 @@ class Complex(abc.ABC):
 
     complex: dict[Any, Any]
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, name: str = "", **kwargs) -> None:
+        self.name = name
         self.complex = dict()
         self.complex.update(kwargs)
 

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -103,9 +103,7 @@ class SimplicialComplex(Complex):
     """
 
     def __init__(self, simplices=None, name: str = "", **kwargs):
-        super().__init__(**kwargs)
-
-        self.name = name
+        super().__init__(name, **kwargs)
 
         self._simplex_set = SimplexView()
 


### PR DESCRIPTION
The `name` is common to all complexes, so let's add it to the `Complex` superclass.

For the future, the dedicated `name` parameter should be removed. Users can store an identifiable name just as well inside complex attributes.