### PR TITLE
Fix attributes when adding cells in CombinatorialComplex

### DIFF
--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -685,36 +685,36 @@ class CombinatorialComplex(Complex):
         """
         if rank in self._complex_set.hyperedge_dict:
             if hyperedge_ in self._complex_set.hyperedge_dict[rank]:
-                self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
                 for i in hyperedge_:
                     if 0 not in self._complex_set.hyperedge_dict:
                         self._complex_set.hyperedge_dict[0] = {}
 
-                    if i not in self._complex_set.hyperedge_dict[0]:
+                    if frozenset({i}) not in self._complex_set.hyperedge_dict[0]:
                         self._complex_set.hyperedge_dict[0][frozenset({i})] = {
                             "weight": 1
                         }
+                self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
             else:
                 self._complex_set.hyperedge_dict[rank][hyperedge_] = {}
-                self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
                 for i in hyperedge_:
                     if 0 not in self._complex_set.hyperedge_dict:
                         self._complex_set.hyperedge_dict[0] = {}
 
-                    if i not in self._complex_set.hyperedge_dict[0]:
+                    if frozenset({i}) not in self._complex_set.hyperedge_dict[0]:
                         self._complex_set.hyperedge_dict[0][frozenset({i})] = {
                             "weight": 1
                         }
+                self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
         else:
             self._complex_set.hyperedge_dict[rank] = {}
             self._complex_set.hyperedge_dict[rank][hyperedge_] = {}
-            self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
 
             for i in hyperedge_:
                 if 0 not in self._complex_set.hyperedge_dict:
                     self._complex_set.hyperedge_dict[0] = {}
-                if i not in self._complex_set.hyperedge_dict[0]:
+                if frozenset({i}) not in self._complex_set.hyperedge_dict[0]:
                     self._complex_set.hyperedge_dict[0][frozenset({i})] = {"weight": 1}
+            self._complex_set.hyperedge_dict[rank][hyperedge_].update(attr)
 
     def _add_hyperedge(self, hyperedge, rank: int, **attr):
         """Add hyperedge.
@@ -760,11 +760,12 @@ class CombinatorialComplex(Complex):
                 if 0 not in self._complex_set.hyperedge_dict:
                     self._complex_set.hyperedge_dict[0] = {}
                 self._complex_set.hyperedge_dict[0][frozenset({hyperedge})] = {}
-                self._complex_set.hyperedge_dict[0][frozenset({hyperedge})].update(attr)
                 self._aux_complex.add_simplex(Simplex(frozenset({hyperedge}), r=0))
                 self._complex_set.hyperedge_dict[0][frozenset({hyperedge})][
                     "weight"
                 ] = 1
+                # update attributes
+                self._complex_set.hyperedge_dict[0][frozenset({hyperedge})].update(attr)
                 return
 
         if isinstance(hyperedge, Hashable) and not isinstance(hyperedge, Iterable):
@@ -774,11 +775,12 @@ class CombinatorialComplex(Complex):
                 if 0 not in self._complex_set.hyperedge_dict:
                     self._complex_set.hyperedge_dict[0] = {}
                 self._complex_set.hyperedge_dict[0][frozenset({hyperedge})] = {}
-                self._complex_set.hyperedge_dict[0][frozenset({hyperedge})].update(attr)
                 self._aux_complex.add_simplex(Simplex(frozenset({hyperedge}), r=0))
                 self._complex_set.hyperedge_dict[0][frozenset({hyperedge})][
                     "weight"
                 ] = 1
+                # update attributes
+                self._complex_set.hyperedge_dict[0][frozenset({hyperedge})].update(attr)
                 return
         if isinstance(hyperedge, Iterable) or isinstance(hyperedge, HyperEdge):
             if not isinstance(hyperedge, HyperEdge):


### PR DESCRIPTION
When adding cells/hyperedges to a Combinatorial Complexes with some attributes, especially nodes, it doesn't work as the dictionnaries are updated not in the right order. Here is a short snippet of code to replicate the unexpected result:

`from toponetx.classes.combinatorial_complex import CombinatorialComplex


CC = CombinatorialComplex()
atom_id = 0
atom_symbol = 'C'
CC.add_cell(
    (atom_id,),
    rank=0,
    symbol=atom_symbol
)
print(CC.cells.hyperedge_dict[0])

# {frozenset({0}): {'weight': 1}}
# instead of
# {frozenset({0}): {'symbol': 'C', 'weight': 1}}`

The few changes in combinatorial_complexes.py that I propose fix this issue.