### PR TITLE
Remove default complex type value in datasets

### DIFF
--- a/test/algorithms/test_spectrum.py
+++ b/test/algorithms/test_spectrum.py
@@ -51,13 +51,13 @@ class TestSpectrum:
 
     def test_laplacian_beltrami_eigenvectors1(self):
         """Test test_set_laplacian_beltrami_eigenvectors."""
-        sc = stanford_bunny()
+        sc = stanford_bunny("simplicial")
         eigenvectors, eigenvalues = laplacian_beltrami_eigenvectors(sc)
         assert len(eigenvalues) == len(sc.nodes)
 
     def test_set_laplacian_beltrami_eigenvectors2(self):
         """Test set_laplacian_beltrami_eigenvectors."""
-        SC = stanford_bunny()
+        SC = stanford_bunny("simplicial")
         set_laplacian_beltrami_eigenvectors(SC)
         vec1 = SC.get_simplex_attributes("1.laplacian_beltrami_eigenvectors")
         assert len(vec1) == len(SC.skeleton(0))

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -616,7 +616,7 @@ class TestSimplicialComplex:
 
     def test_is_triangular_mesh(self):
         """Test is_triangular_mesh."""
-        SC = stanford_bunny()
+        SC = stanford_bunny("simplicial")
         assert SC.is_triangular_mesh()
 
         # test for non triangular mesh
@@ -628,7 +628,7 @@ class TestSimplicialComplex:
 
     def test_to_trimesh(self):
         """Test to_trimesh."""
-        SC = stanford_bunny()
+        SC = stanford_bunny("simplicial")
         trimesh_obj = SC.to_trimesh()
         assert len(trimesh_obj.vertices) == len(SC.skeleton(0))
 
@@ -642,7 +642,7 @@ class TestSimplicialComplex:
 
     def test_laplace_beltrami_operator(self):
         """Test laplace_beltrami_operator."""
-        SC = stanford_bunny()
+        SC = stanford_bunny("simplicial")
 
         laplacian_matrix = SC.laplace_beltrami_operator()
 
@@ -658,7 +658,7 @@ class TestSimplicialComplex:
 
     def test_is_connected(self):
         """Test is connected."""
-        SC = stanford_bunny()
+        SC = stanford_bunny("simplicial")
         assert SC.is_connected()
 
     def test_simplicial_closure_of_hypergraph(self):

--- a/toponetx/datasets/graph.py
+++ b/toponetx/datasets/graph.py
@@ -16,27 +16,25 @@ DIR = Path(__file__).parent
 
 
 @overload
-def karate_club(
-    complex_type: Literal["cell"] = ..., feat_dim: int = ...
-) -> CellComplex:
+def karate_club(complex_type: Literal["cell"], feat_dim: int = ...) -> CellComplex:
     ...
 
 
 @overload
 def karate_club(
-    complex_type: Literal["simplicial"] = ..., feat_dim: int = ...
+    complex_type: Literal["simplicial"], feat_dim: int = ...
 ) -> SimplicialComplex:
     ...
 
 
 def karate_club(
-    complex_type: Literal["cell", "simplicial"] = "simplicial", feat_dim: int = 2
+    complex_type: Literal["cell", "simplicial"], feat_dim: int = 2
 ) -> CellComplex | SimplicialComplex:
     """Load the karate club as featured cell/simplicial complex.
 
     Parameters
     ----------
-    complex_type : {'simplicial','cell'}, default='simplicial'
+    complex_type : {'simplicial','cell'}
         The type of complex to load.
     feat_dim : int, default=2
         The number of eigenvectors to be attached to the simplices/cells

--- a/toponetx/datasets/mesh.py
+++ b/toponetx/datasets/mesh.py
@@ -38,23 +38,23 @@ COSEG_DS_MAP = {
 
 
 @overload
-def stanford_bunny(complex_type: Literal["cell"] = ...) -> CellComplex:
+def stanford_bunny(complex_type: Literal["cell"]) -> CellComplex:
     ...
 
 
 @overload
-def stanford_bunny(complex_type: Literal["simplicial"] = ...) -> SimplicialComplex:
+def stanford_bunny(complex_type: Literal["simplicial"]) -> SimplicialComplex:
     ...
 
 
 def stanford_bunny(
-    complex_type: Literal["cell", "simplicial"] = "simplicial"
+    complex_type: Literal["cell", "simplicial"]
 ) -> CellComplex | SimplicialComplex:
     """Load the Stanford Bunny mesh as a complex.
 
     Parameters
     ----------
-    complex_type : {'cell', 'simplicial'}, default='simplicial'
+    complex_type : {'cell', 'simplicial'}
         The type of complex to load. Supported values are
         "simplicial complex" and "cell complex".
         The default is "simplicial complex".


### PR DESCRIPTION
I guess this is a bit of a controversial one, but I would suggest to remove the default value for the `complex_type` parameters in the datasets. It is not obvious why a simplicial complex is returned by default but you can switch to a cell complex.

This way, the user has to be explicit about what they want and their code is more readable. Plus this makes type hints easier on our end (overloads with default values aren't nice...) 😄