### PR TITLE
Improve performance of graph to clique complex lifting

### DIFF
--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -1,5 +1,5 @@
 """Methods to lift a graph to a simplicial complex."""
-
+from itertools import takewhile
 from warnings import warn
 
 import networkx as nx
@@ -57,8 +57,11 @@ def graph_to_clique_complex(
         The clique simplicial complex of dimension dim of the graph G.
     """
     cliques = nx.enumerate_all_cliques(G)
+
+    # `nx.enumerate_all_cliques` returns cliques in ascending order of size. Abort calling the generator once we reach
+    # cliques larger than the requested max dimension.
     if max_dim is not None:
-        cliques = filter(lambda clique: len(clique) <= max_dim, cliques)
+        cliques = takewhile(lambda clique: len(clique) <= max_dim, cliques)
 
     return SimplicialComplex(cliques)
 


### PR DESCRIPTION
[`nx.enumerate_all_cliques`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.clique.enumerate_all_cliques.html) guarantees that cliques are yielded in ascending order. We can thus abort calling the generator once the the first clique of larger dimension than requested is returned.
This improves performance, as cliques of size larger than `max_dim` are not computed anymore. Previously, *all* cliques have been computed, only to immediately discard those that are too large.