### PR TITLE
Copy attributes in clique lifting

### DIFF
--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -32,8 +32,10 @@ class TestGraphToSimplicialComplex:
     def test_graph_to_clique_complex(self):
         """Test graph_2_clique_complex."""
         G = nx.Graph()
+        G.graph["label"] = 12
 
-        G.add_edge(0, 1)
+        G.add_node(0, label=5)
+        G.add_edge(0, 1, weight=10)
         G.add_edge(1, 2)
         G.add_edge(2, 0)
         G.add_edge(2, 3)
@@ -44,6 +46,11 @@ class TestGraphToSimplicialComplex:
         assert sc.dim == 2
         assert (0, 2, 3) in sc
         assert (0, 1, 2) in sc
+
+        # attributes are copied
+        assert sc.complex["label"] == 12
+        assert sc[(0,)]["label"] == 5
+        assert sc[(0, 1)]["weight"] == 10
 
         sc = graph_to_clique_complex(G, max_dim=2)
 

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -63,7 +63,16 @@ def graph_to_clique_complex(
     if max_dim is not None:
         cliques = takewhile(lambda clique: len(clique) <= max_dim, cliques)
 
-    return SimplicialComplex(cliques)
+    SC = SimplicialComplex(cliques)
+
+    # copy attributes of the input graph
+    for node in G.nodes:
+        SC[[node]].update(G.nodes[node])
+    for edge in G.edges:
+        SC[edge].update(G.edges[edge])
+    SC.complex.update(G.graph)
+
+    return SC
 
 
 def graph_2_neighbor_complex(G) -> SimplicialComplex:


### PR DESCRIPTION
With this pull request, any node, edge, and graph attributes will be copied over to the clique complex. In a sense, the simplicial complex is exactly as the input graph, only that all cliques are filled-in with higher-order simplices.