### PR TITLE
Deprecate simplex tree construction in `Simplex`.

### DIFF
--- a/test/classes/test_simplex.py
+++ b/test/classes/test_simplex.py
@@ -13,9 +13,11 @@ class TestSimplex:
         s = Simplex((1,))
         assert len(s) == 1
         assert tuple(s) == (1,)
-        assert s.construct_tree is True
         assert s.name == ""
         assert s._properties == {}
+
+        with pytest.deprecated_call():
+            _ = Simplex((1,), construct_tree=True)
 
     def test_duplicate_nodes(self):
         """Test creation of simplex with duplicate nodes."""
@@ -33,8 +35,9 @@ class TestSimplex:
     def test_boundary(self):
         """Test the boundary property of the simplex."""
         s = Simplex((1, 2, 3))
-        boundary = s.boundary
-        assert len(boundary) == 3
+        with pytest.deprecated_call():
+            boundary = s.boundary
+            assert len(boundary) == 3
 
     def test_representation(self):
         """Test the string representation of the simplex."""
@@ -68,12 +71,14 @@ class TestSimplex:
     def test_faces(self):
         """Test getting faces from simplex."""
         s = Simplex((1, 2, 3), constuct_tree=False)
-        faces = s.faces
-        assert len(faces) == 7
+        with pytest.deprecated_call():
+            faces = s.faces
+            assert len(faces) == 7
 
         s = Simplex((1, 2, 3), constuct_tree=True)
-        faces = s.faces
-        assert len(faces) == 7
+        with pytest.deprecated_call():
+            faces = s.faces
+            assert len(faces) == 7
 
     def test_clone(self):
         """Test clone method."""

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -100,11 +100,10 @@ class Simplex(Atom):
     @property
     def boundary(self) -> frozenset["Simplex"]:
         """Return a set of Simplex objects representing the boundary faces."""
-        if self.construct_tree:
-            return frozenset(i for i in self._faces if len(i) == len(self) - 1)
-        else:
-            faces = Simplex.construct_simplex_tree(self.elements)
-            return frozenset(i for i in faces if len(i) == len(self) - 1)
+        return frozenset(
+            Simplex(elements, construct_tree=False)
+            for elements in combinations(self.elements, len(self) - 1)
+        )
 
     def sign(self, face) -> int:
         """Calculate the sign of the simplex with respect to a given face.

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -1,6 +1,7 @@
 """Simplex Class."""
 
-from collections.abc import Collection, Hashable, Iterable, Iterator
+import warnings
+from collections.abc import Collection, Hashable, Iterable
 from itertools import combinations
 from typing import Any
 
@@ -41,8 +42,14 @@ class Simplex(Atom):
     """
 
     def __init__(
-        self, elements: Collection, name: str = "", construct_tree: bool = True, **attr
+        self, elements: Collection, name: str = "", construct_tree: bool = False, **attr
     ) -> None:
+        if construct_tree is not False:
+            warnings.warn(
+                "The `construct_tree` argument is deprecated.",
+                DeprecationWarning,
+            )
+
         for i in elements:
             if not isinstance(i, Hashable):
                 raise ValueError(f"All nodes of a simplex must be hashable, got {i}")
@@ -50,12 +57,6 @@ class Simplex(Atom):
         super().__init__(frozenset(sorted(elements)), name, **attr)
         if len(elements) != len(self.elements):
             raise ValueError("A simplex cannot contain duplicate nodes.")
-
-        self.construct_tree = construct_tree
-        if construct_tree:
-            self._faces = self.construct_simplex_tree(elements)
-        else:
-            self._faces = frozenset()
 
     def __contains__(self, item: Any) -> bool:
         """Return True if the given element is a subset of the nodes.
@@ -89,6 +90,10 @@ class Simplex(Atom):
     @staticmethod
     def construct_simplex_tree(elements: Collection) -> frozenset["Simplex"]:
         """Return set of Simplex objects representing the faces."""
+        warnings.warn(
+            "`Simplex.construct_simplex_tree` is deprecated.", DeprecationWarning
+        )
+
         faceset = set()
         for r in range(len(elements), 0, -1):
             for face in combinations(elements, r):
@@ -100,6 +105,11 @@ class Simplex(Atom):
     @property
     def boundary(self) -> frozenset["Simplex"]:
         """Return a set of Simplex objects representing the boundary faces."""
+        warnings.warn(
+            "`Simplex.boundary` is deprecated, use `SimplicialComplex.get_boundaries()` on the simplicial complex that contains this simplex instead.",
+            DeprecationWarning,
+        )
+
         return frozenset(
             Simplex(elements, construct_tree=False)
             for elements in combinations(self.elements, len(self) - 1)
@@ -127,10 +137,12 @@ class Simplex(Atom):
         frozenset[Simplex]
             The set of faces of the simplex.
         """
-        if self.construct_tree:
-            return self._faces
-        else:
-            return Simplex.construct_simplex_tree(self.elements)
+        warnings.warn(
+            "`Simplex.faces` is deprecated, use `SimplicialComplex.get_boundaries()` on the simplicial complex that contains this simplex instead.",
+            DeprecationWarning,
+        )
+
+        return Simplex.construct_simplex_tree(self.elements)
 
     def __repr__(self) -> str:
         """Return string representation of the simplex.


### PR DESCRIPTION
This pull request deprecates `Simplex.boundary` and `Simplex.faces`. As a simplex has no knowledge of the SC it belongs to, the sub-simplices returned by both functions lack any user-defined parameters that were given when constructing the simplicial complex. Going through appropriate methods in `SimplicialComplex` avoids this problem.

With the deprecation of the above functions, I also removed the simplex tree construction inside of the `Simplex` class. The default value `construct_tree=True` meant a significant performance implication.
In fact, we have fallen into this trap ourself inside TopoNetX at least once: The `Simplex` construction in `SimplicialComplex.__init__` does not set this parameter to false even though it definitely should have been.