### PR TITLE
fixing iter for complexes and making them all behave the same way

### DIFF
--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -1073,7 +1073,7 @@ class PathComplex(Complex):
         -------
         dict_keyiterator
         """
-        return chain.from_iterable(self._path_set.faces_dict)
+        return iter(self.nodes)
 
     def __len__(self) -> int:
         """Return the number of elementary p-paths in the path complex.

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -250,7 +250,7 @@ class SimplicialComplex(Complex):
         -------
         dict_keyiterator
         """
-        return chain.from_iterable(self._simplex_set.faces_dict)
+        return chain.from_iterable(self.nodes)
 
     def __contains__(self, item) -> bool:
         """Return boolean indicating if item is in self.face_set.


### PR DESCRIPTION
This is addressing #266 in one way. 

__iter__ now iterates over the nodes of the complex, consistent with NetworkX. 

complex.cells, complex.paths, complex.simplices can be used to iterate over the atoms in each class.

combinatorial complex inherets from chg and no need to have its own iter method. 