### PR TITLE
Clean-up `isinstance` calls

### DIFF
--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -270,7 +270,7 @@ class Cell(Atom):
             of them can be obtaine from the other by a cylic rotation
             of the boundary verties defining the 2d cells.
         """
-        if isinstance(cell, tuple) or isinstance(cell, list):
+        if isinstance(cell, (tuple, list)):
             seq = cell
         elif isinstance(cell, Cell):
             seq = cell.elements

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -460,7 +460,7 @@ class ColoredHyperGraph(Complex):
             if rank != 0:
                 raise ValueError(f"rank must be zero for hashables, got rank {rank}")
             hyperedge_set = frozenset({hyperedge})
-        elif isinstance(hyperedge, Iterable) or isinstance(hyperedge, HyperEdge):
+        elif isinstance(hyperedge, (Iterable, HyperEdge)):
             if isinstance(hyperedge, HyperEdge):
                 hyperedge_set = hyperedge.elements
             else:

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -503,7 +503,7 @@ class CombinatorialComplex(ColoredHyperGraph):
             if rank != 0:
                 raise ValueError(f"rank must be zero for hashables, got rank {rank}")
             hyperedge_set = frozenset({hyperedge})
-        elif isinstance(hyperedge, Iterable) or isinstance(hyperedge, HyperEdge):
+        elif isinstance(hyperedge, (Iterable, HyperEdge)):
             if isinstance(hyperedge, HyperEdge):
                 hyperedge_ = hyperedge.elements
             else:

--- a/toponetx/classes/path.py
+++ b/toponetx/classes/path.py
@@ -83,7 +83,7 @@ class Path(Atom):
         **attr,
     ) -> None:
         self.__check_inputs(elements, reserve_sequence_order)
-        if isinstance(elements, int) or isinstance(elements, str):
+        if isinstance(elements, (int, str)):
             elements = [elements]
         super().__init__(tuple(elements), name, **attr)
         if len(set(elements)) != len(self.elements):

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -135,16 +135,11 @@ class PathComplex(Complex):
             # add all simple paths
             self.add_paths_from(self._allowed_paths)
 
-        elif isinstance(paths, list) or isinstance(paths, tuple):
+        elif isinstance(paths, (list, tuple)):
             tmp_paths = []
             for path in paths:
                 if len(path) <= max_rank + 1:
-                    if (
-                        isinstance(paths[0], int)
-                        or isinstance(paths[0], str)
-                        or isinstance(paths[0], list)
-                        or isinstance(paths[0], tuple)
-                    ):
+                    if isinstance(paths[0], (int, str, list, tuple)):
                         tmp_paths.append(tuple(path))
                     else:  # path is a Path object
                         tmp_paths.append(path)
@@ -206,11 +201,11 @@ class PathComplex(Complex):
 
         """
         new_paths = set()
-        if isinstance(path, int) or isinstance(path, str):
+        if isinstance(path, (int, str)):
             path = [
                 path,
             ]
-        if isinstance(path, list) or isinstance(path, tuple) or isinstance(path, Path):
+        if isinstance(path, (list, tuple, Path)):
             if not isinstance(path, Path):  # path is a list or tuple
                 path_ = tuple(path)
                 if len(path) != len(set(path)):
@@ -810,12 +805,12 @@ class PathComplex(Complex):
                 if isinstance(value, dict):
                     for k, v in value.items():
                         self[node][k] = v
-                        if isinstance(node, tuple) or isinstance(node, list):
+                        if isinstance(node, (tuple, list)):
                             if len(node) == 1:
                                 self._G.nodes[node[0]][k] = v
                             else:
                                 raise ValueError("Input node must be a singleton.")
-                        elif isinstance(node, int) or isinstance(node, str):
+                        elif isinstance(node, (int, str)):
                             self._G.nodes[node][k] = v
                 else:
                     raise TypeError(
@@ -824,12 +819,12 @@ class PathComplex(Complex):
         else:
             for node, value in values.items():
                 self[node][name] = value
-                if isinstance(node, tuple) or isinstance(node, list):
+                if isinstance(node, (tuple, list)):
                     if len(node) == 1:
                         self._G.nodes[node[0]][name] = value
                     else:
                         raise ValueError("Input node must be a singleton.")
-                elif isinstance(node, int) or isinstance(node, str):
+                elif isinstance(node, (int, str)):
                     self._G.nodes[node][name] = value
 
     def get_edge_attributes(self, name: str) -> dict[tuple[Hashable], Any]:
@@ -912,7 +907,7 @@ class PathComplex(Complex):
                 if len(edge) != 2:
                     raise ValueError("Input edge must be a pair.")
                 self[edge][name] = value
-                if isinstance(edge, tuple) or isinstance(edge, list):
+                if isinstance(edge, (tuple, list)):
                     self._G.edges[edge[0], edge[1]][name] = value
 
     def get_path_attributes(self, name: str) -> dict[tuple[Hashable], Any]:
@@ -994,7 +989,7 @@ class PathComplex(Complex):
                     )
         else:
             for path, value in values.items():
-                if isinstance(path, int) or isinstance(path, str) or len(path) == 1:
+                if isinstance(path, (int, str)) or len(path) == 1:
                     self.set_node_attributes({path: {name: value}})
                 elif len(path) == 2:
                     self.set_edge_attributes({path: {name: value}})

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -74,7 +74,7 @@ class CellView:
                 ]
 
         # If a tuple or list is passed in, assume it represents a cell
-        elif isinstance(cell, tuple) or isinstance(cell, list):
+        elif isinstance(cell, (tuple, list)):
             cell = tuple(cell)
             if cell in self._cells:
                 if len(self._cells[cell]) == 1:
@@ -124,7 +124,7 @@ class CellView:
                 ]
 
         # If a tuple or list is passed in, assume it represents a cell
-        elif isinstance(cell, tuple) or isinstance(cell, list):
+        elif isinstance(cell, (tuple, list)):
             cell = tuple(cell)
             if cell in self._cells:
                 if len(self._cells[cell]) == 1:
@@ -166,14 +166,9 @@ class CellView:
             Whether or not the element is in the cell view.
         """
         while True:
-            if isinstance(e, Cell):
+            if isinstance(e, (Cell, tuple, list)):
                 break
-            elif isinstance(e, tuple):
-                break
-            elif isinstance(e, list):
-                break
-            else:
-                raise TypeError("Input must be of type: tuple, list or a cell.")
+            raise TypeError("Input must be of type: tuple, list or a cell.")
 
         e = Cell(e)
         e_homotopic_to = [e.is_homotopic_to(x) for x in self._cells]

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -466,7 +466,7 @@ class SimplicialComplex(Complex):
             simplex = [simplex]
         if isinstance(simplex, str):
             simplex = [simplex]
-        if isinstance(simplex, Iterable) or isinstance(simplex, Simplex):
+        if isinstance(simplex, (Iterable, Simplex)):
             if not isinstance(simplex, Simplex):
                 simplex_ = frozenset(simplex)
                 if len(simplex_) != len(simplex):


### PR DESCRIPTION
`isinstance` takes a tuple as second argument `isinstance(obj, (ONE, TWO))`, which is equivalent to chaining multiple checks `isinstance(obj, ONE) or isinstance(obj, TWO)`. Clean this up across the codebase.