### PR TITLE
Setup intersphinx for our documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,5 @@
 """Sphinx configuration file."""
 
-import toponetx
-
 project = "TopoNetX"
 copyright = "2022-2023, PyT-Team, Inc."
 author = "PyT-Team Authors"
@@ -13,6 +11,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
@@ -27,7 +26,7 @@ napoleon_use_ivar = False
 napoleon_use_rtype = False
 napoleon_include_init_with_doc = False
 
-# Configure nbsphinx for notebooks execution
+# Configure nbsphinx for notebook execution
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
     "--InlineBackend.rc={'figure.dpi': 96}",
@@ -112,3 +111,11 @@ texinfo_documents = [
 
 epub_title = project
 epub_exclude_files = ["search.html"]
+
+# Configure intersphinx
+intersphinx_mapping = {
+    "networkx": ("https://networkx.org/documentation/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+}


### PR DESCRIPTION
This links occurrences of `networkx.Graph`, `numpy.ndarray` and so on in function signatures to the documentation of the respective project.

| Before | After |
|-------|----|
| <img width="740" alt="Bildschirmfoto 2023-10-27 um 15 42 03" src="https://github.com/pyt-team/TopoNetX/assets/2105496/026472dc-bcf1-4e60-aba8-72336b44d5b5"> | <img width="740" alt="Bildschirmfoto 2023-10-27 um 15 41 28" src="https://github.com/pyt-team/TopoNetX/assets/2105496/ea427291-01e1-4a0c-8d8a-68ec67e25c06"> |
| | (`Graph`, `int` and `None` are linked)
