### PR TITLE
Changing pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11"
 ]
-requires-python = ">= 3.10"
+python_requires='>=3.10,<3.12'
 dependencies=[
     "gudhi",
     "decorator",


### PR DESCRIPTION
Changing pyproject.toml file to resolve issues #321 and #320. pyproject.toml was not enforcing build constraints, and also was allowing python=3.12.0 which is breaking the build.