### PR TITLE
Remove `name` feature across codebase

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -795,8 +795,8 @@ class TestCellComplex:
 
     def test_repr(self):
         """Test the string representation of the cell complex."""
-        CC = CellComplex(name="test")
-        assert repr(CC) == "CellComplex(name='test')"
+        CC = CellComplex()
+        assert repr(CC) == "CellComplex()"
 
     def test_len(self):
         """Test the length of the cell complex."""

--- a/test/classes/test_colored_hypergraph.py
+++ b/test/classes/test_colored_hypergraph.py
@@ -97,8 +97,8 @@ class TestCombinatorialComplex:
 
     def test_chg_repr(self):
         """Test CHG repr representation."""
-        CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2, name="chg_test")
-        assert repr(CHG) == f"ColoredHyperGraph(name='{CHG.name}')"
+        CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
+        assert repr(CHG) == "ColoredHyperGraph()"
 
     def test_chg_iter(self):
         """Test CHG iter."""

--- a/test/classes/test_combinatorial_complex.py
+++ b/test/classes/test_combinatorial_complex.py
@@ -330,8 +330,8 @@ class TestCombinatorialComplex:
 
     def test_repr(self):
         """Test the represntation function of the CombinatorialComplex object by mentioning a name."""
-        CCC = CombinatorialComplex(name="sampleobject")
-        assert repr(CCC) == "CombinatorialComplex(name='sampleobject')"
+        CCC = CombinatorialComplex()
+        assert repr(CCC) == "CombinatorialComplex()"
 
     def test_contains(self):
         """Test whether the contains method works correctly."""

--- a/test/classes/test_hyperedge.py
+++ b/test/classes/test_hyperedge.py
@@ -88,14 +88,6 @@ class TestHyperEdgeCases:
         he = HyperEdge([1, 5, 2])
         assert he.rank is None
 
-    def test_name(self):
-        """Test name."""
-        he = HyperEdge([1, 4, 2], rank=4)
-        assert he.name == ""
-
-        he = HyperEdge([1, 4, 2], name="A")
-        assert he.name == "A"
-
     def test_eq(self):
         """Test eq."""
         he1 = HyperEdge((1, 4, 2), rank=4)

--- a/test/classes/test_path.py
+++ b/test/classes/test_path.py
@@ -14,7 +14,6 @@ class TestPath:
         assert len(s) == 1
         assert tuple(s) == (1,)
         assert s.construct_boundaries is False
-        assert s.name == ""
         assert s._attributes == {}
 
     def test_invalid_inputs(self):

--- a/test/classes/test_path_complex.py
+++ b/test/classes/test_path_complex.py
@@ -196,9 +196,8 @@ class TestPathComplex:
 
     def test_repr_str(self):
         """Test repr str."""
-        PC = PathComplex([[1, 2, 3], [1, 2, 4]], name="PC")
-        assert (repr(PC)) == "PathComplex(name='PC')"
-        assert PC.name == "PC"
+        PC = PathComplex([[1, 2, 3], [1, 2, 4]])
+        assert (repr(PC)) == "PathComplex()"
 
     def test_getittem_set_attributes(self):
         """Test getitem and set_attributes methods."""

--- a/test/classes/test_reportviews.py
+++ b/test/classes/test_reportviews.py
@@ -275,7 +275,7 @@ class TestReportViews_HyperEdgeView:
 
     def test_hyper_edge_view_contains(self):
         """Test the __contains__ method for the Hyperedge View Class."""
-        hev = HyperEdgeView(name="testing_hev")
+        hev = HyperEdgeView()
 
         he_1 = HyperEdge((1, 2, 3, 4), rank=2)
         he_2 = HyperEdge({1, 2, 3, 5}, rank=2)
@@ -654,17 +654,17 @@ class TestReportViews_PathView:
     """Test the PathView class of the ReportViews module."""
 
     path_1 = Path((1,), name="path_1", weight=5)
-    path_2 = Path((1, 2), name="path_2", weight=10)
-    path_3 = Path((1, 2, 3), name="path_3")
+    path_2 = Path((1, 2), weight=10)
+    path_3 = Path((1, 2, 3))
 
     pc = PathComplex([path_1, path_2, path_3])
     path_view = pc.paths
 
     def test_get_item(self):
         """Test the __getitem__ method of the PathView class."""
-        assert self.path_view.__getitem__((1,)) == {"weight": 5}
-        assert self.path_view.__getitem__(1) == {"weight": 5}
-        assert self.path_view.__getitem__(Path(1)) == {"weight": 5}
+        assert self.path_view.__getitem__((1,)) == {"name": "path_1", "weight": 5}
+        assert self.path_view.__getitem__(1) == {"name": "path_1", "weight": 5}
+        assert self.path_view.__getitem__(Path(1)) == {"name": "path_1", "weight": 5}
         assert self.path_view.__getitem__((2, 3)) == {}
         assert self.path_view.__getitem__((1, 2)) == {"weight": 10}
         assert self.path_view.__getitem__((1, 2, 3)) == {}

--- a/test/classes/test_simplex.py
+++ b/test/classes/test_simplex.py
@@ -13,7 +13,6 @@ class TestSimplex:
         s = Simplex((1,))
         assert len(s) == 1
         assert tuple(s) == (1,)
-        assert s.name == ""
         assert s._attributes == {}
 
         with pytest.deprecated_call():

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -116,9 +116,8 @@ class TestSimplicialComplex:
         G.add_edge(0, 1)
         G.add_edge(2, 5)
         G.add_edge(5, 4, weight=5)
-        SC = SimplicialComplex(G, name="graph complex")
-        assert (repr(SC)) == "SimplicialComplex(name='graph complex')"
-        assert SC.name == "graph complex"
+        SC = SimplicialComplex(G)
+        assert (repr(SC)) == "SimplicialComplex()"
 
     def test_iter(self):
         """Test iter method."""

--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -20,8 +20,6 @@ class Cell(Atom):
     elements : iterable of hashable objects
         An iterable that contains hashable objects representing the nodes of the cell. The order of the elements is important
         and defines the cell up to cyclic permutation.
-    name : str, optional
-        A string representing the name of the cell.
     regular : bool, optional
         A boolean indicating whether the cell satisfies the regularity condition. The default value is True.
         A 2D cell is regular if and only if there is no repetition in the boundary edges that define the cell.
@@ -58,9 +56,7 @@ class Cell(Atom):
     ((0, 1), (0, 0))]
     """
 
-    def __init__(
-        self, elements: Collection, name: str = "", regular: bool = True, **kwargs
-    ) -> None:
+    def __init__(self, elements: Collection, regular: bool = True, **kwargs) -> None:
         """Initialize class representing a 2D cell.
 
         A 2D cell is an elementary building block used to build a 2D cell complex, whether regular or non-regular.
@@ -70,8 +66,6 @@ class Cell(Atom):
         elements : Collection[Hashable]
             An iterable that contains hashable objects representing the nodes of the cell. The order of the elements is important
             and defines the cell up to cyclic permutation.
-        name : str, optional
-            A string representing the name of the cell.
         regular : bool, optional
             A boolean indicating whether the cell satisfies the regularity condition. The default value is True.
             A 2D cell is regular if and only if there is no repetition in the boundary edges that define the cell.
@@ -80,7 +74,7 @@ class Cell(Atom):
         **kwargs : keyword arguments, optional
             Attributes belonging to the cell can be added as key-value pairs. Both the key and value must be hashable.
         """
-        super().__init__(tuple(elements), name, **kwargs)
+        super().__init__(tuple(elements), **kwargs)
 
         self._regular = regular
         elements = list(elements)
@@ -120,7 +114,7 @@ class Cell(Atom):
         Cell
             A copy of this cell.
         """
-        return Cell(self.elements, self.name, self._regular, **self._attributes)
+        return Cell(self.elements, self._regular, **self._attributes)
 
     @staticmethod
     def is_valid_cell(elements: Sequence, regular: bool = False) -> bool:
@@ -259,7 +253,6 @@ class Cell(Atom):
         """
         return Cell(
             self.elements[::-1],
-            name=self.name,
             regular=self._regular,
             **self._attributes,
         )

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -81,8 +81,6 @@ class CellComplex(Complex):
     ----------
     cells : iterable, optional
         A list of cells to add to the complex.
-    name : str, optional
-        Name of the complex.
     regular : bool, default=True
         If True, then the complex is regular, otherwise it is non-regular.
     **kwargs : keyword arguments, optional
@@ -138,23 +136,19 @@ class CellComplex(Complex):
     >>> CC.is_regular
     """
 
-    def __init__(
-        self, cells=None, name: str = "", regular: bool = True, **kwargs
-    ) -> None:
+    def __init__(self, cells=None, regular: bool = True, **kwargs) -> None:
         """Initialize a new Cell Complex.
 
         Parameters
         ----------
         cells : iterable, optional
             A list of cells to add to the complex.
-        name : str, optional
-            Name of the complex.
         regular : bool, default=True
             If True, then the complex is regular, otherwise it is non-regular.
         **kwargs : keyword arguments, optional
             Attributes to add to the complex as key=value pairs.
         """
-        super().__init__(name, **kwargs)
+        super().__init__(**kwargs)
 
         self._regular = regular
         self._G = Graph()
@@ -328,7 +322,7 @@ class CellComplex(Complex):
         str
             The __repr__ representation of the Cell Complex.
         """
-        return f"CellComplex(name='{self.name}')"
+        return "CellComplex()"
 
     def __len__(self) -> int:
         """Return number of nodes.
@@ -393,7 +387,7 @@ class CellComplex(Complex):
         # input must be list, tuple or Cell type
         if isinstance(cell, (tuple, list, Cell)):
             if isinstance(cell, (tuple, list)):
-                cell = Cell(elements=cell, name=str(len(self.cells)), **attr)
+                cell = Cell(elements=cell, **attr)
             elif isinstance(cell, Cell):
                 cell.update(attr)
 
@@ -2087,7 +2081,6 @@ class CellComplex(Complex):
         self,
         cell_set: Iterable[Cell | tuple],
         keep_edges: bool = False,
-        name: str = "",
     ):
         """Construct cell complex using a subset of the cells in cell complex.
 
@@ -2099,8 +2092,6 @@ class CellComplex(Complex):
         keep_edges : bool, default=False
             If False, discards edges not required by or included in `cell_set`
             If True, all previous edges are kept.
-        name : str, optional
-            Name of the restricted cell complex.
 
         Returns
         -------
@@ -2119,7 +2110,7 @@ class CellComplex(Complex):
         >>> cx1.cells
         CellView([Cell(1, 2, 3)])
         """
-        CC = CellComplex(cells=self._G.copy(), name=name)
+        CC = CellComplex(cells=self._G.copy())
 
         edges = set()
 
@@ -2157,7 +2148,7 @@ class CellComplex(Complex):
 
         return CC
 
-    def restrict_to_nodes(self, node_set: Iterable[Hashable], name: str = ""):
+    def restrict_to_nodes(self, node_set: Iterable[Hashable]):
         """Restrict cell complex to nodes.
 
         This constructs a new cell complex by restricting the cells in the cell complex to
@@ -2167,8 +2158,6 @@ class CellComplex(Complex):
         ----------
         node_set : iterable of hashables
             The nodes to restrict the cell complex to.
-        name : str, optional
-            Name of the restricted cell complex.
 
         Returns
         -------
@@ -2186,7 +2175,7 @@ class CellComplex(Complex):
         >>> CC.restrict_to_nodes([1, 2, 3, 0])
         """
         _G = Graph(self._G.subgraph(node_set))
-        CC = CellComplex(_G, name)
+        CC = CellComplex(_G)
         cells = []
         for cell in self.cells:
             if CC.is_insertable_cycle(cell, True):
@@ -2351,7 +2340,7 @@ class CellComplex(Complex):
         >>> CX2 = CC.clone()
         """
         _G = self._G.copy()
-        CC = CellComplex(_G, self.name)
+        CC = CellComplex(_G)
         for cell in self.cells:
             CC.add_cell(cell.clone())
         return CC

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -27,8 +27,6 @@ class ColoredHyperGraph(Complex):
     ----------
     cells : Collection, optional
         The initial collection of cells in the Colored Hypergraph.
-    name : str, optional
-        An identifiable name for the Colored Hypergraph.
     ranks : Collection, optional
         Represents the color of cells.
     **kwargs : keyword arguments, optional
@@ -38,7 +36,6 @@ class ColoredHyperGraph(Complex):
     def __init__(
         self,
         cells: Collection | None = None,
-        name: str = "",
         ranks: Collection | int | None = None,
         **kwargs,
     ) -> None:
@@ -56,8 +53,6 @@ class ColoredHyperGraph(Complex):
         ----------
         cells : Collection, optional
             The initial collection of cells in the Colored Hypergraph.
-        name : str, optional
-            An identifiable name for the Colored Hypergraph.
         ranks : Collection, optional
             Represents the color of cells.
         **kwargs : keyword arguments, optional
@@ -97,7 +92,6 @@ class ColoredHyperGraph(Complex):
         """
         super().__init__(**kwargs)
 
-        self.name = name
         self._complex_set = ColoredHyperEdgeView()
 
         if cells is not None:
@@ -247,7 +241,7 @@ class ColoredHyperGraph(Complex):
         str
             A string representation.
         """
-        return f"ColoredHyperGraph(name='{self.name}')"
+        return "ColoredHyperGraph()"
 
     def __len__(self) -> int:
         """Return the number of nodes in the colored hypergraph.
@@ -1464,40 +1458,28 @@ class ColoredHyperGraph(Complex):
         """
         raise NotImplementedError()
 
-    def restrict_to_cells(self, cell_set, name: str | None = None):
+    def restrict_to_cells(self, cell_set):
         """Construct a Colored Hypergraph using a subset of the cells.
 
         Parameters
         ----------
         cell_set : hashable
             A subset of elements of the Colored Hypergraph cells.
-        name : str, optional
-            An identifiable name for the new Colored Hypergraph.
 
         Returns
         -------
         ColoredHyperGraph
             The Colored Hypergraph constructed from the specified subset of cells.
         """
-        from toponetx.classes.combinatorial_complex import CombinatorialComplex
-
-        if isinstance(self, ColoredHyperGraph) and not isinstance(
-            self, CombinatorialComplex
-        ):
-            chg = ColoredHyperGraph(name)
-        elif isinstance(self, CombinatorialComplex):
-            chg = CombinatorialComplex(name)
-        valid_cells = []
-        for c in cell_set:
-            if c in self.cells:
-                valid_cells.append(c)
+        chg = self.__class__()
+        valid_cells = [c for c in cell_set if c in self.cells]
         for c in valid_cells:
             if not isinstance(c, Iterable):
                 raise ValueError(f"each element in cell_set must be Iterable, got {c}")
             chg.add_cell(c, rank=self.cells.get_rank(c))
         return chg
 
-    def restrict_to_nodes(self, node_set, name: str | None = None):
+    def restrict_to_nodes(self, node_set):
         """Restrict to a set of nodes.
 
         Constructs a new Colored Hypergraph by restricting the
@@ -1508,22 +1490,13 @@ class ColoredHyperGraph(Complex):
         ----------
         node_set : iterable of hashables
             References a subset of elements of self.nodes.
-        name : str, optional
-            An identifiable name for the new Colored Hypergraph.
 
         Returns
         -------
         ColoredHyperGraph
             A new Colored Hypergraph restricted to the specified node_set.
         """
-        from toponetx.classes.combinatorial_complex import CombinatorialComplex
-
-        if isinstance(self, ColoredHyperGraph) and not isinstance(
-            self, CombinatorialComplex
-        ):
-            chg = ColoredHyperGraph(name)
-        elif isinstance(self, CombinatorialComplex):
-            chg = CombinatorialComplex(name)
+        chg = self.__class__()
         node_set = frozenset(node_set)
         for i in self.ranks:
             if i != 0:
@@ -1609,7 +1582,7 @@ class ColoredHyperGraph(Complex):
         ColoredHyperGraph
             ColoredHyperGraph.
         """
-        CHG = ColoredHyperGraph(name=self.name)
+        CHG = ColoredHyperGraph()
         for cell, key in self.cells:
             CHG.add_cell(cell, key=key, rank=self.cells.get_rank(cell))
         return CHG

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -40,8 +40,6 @@ class CombinatorialComplex(ColoredHyperGraph):
     ----------
     cells : Collection, optional
         A collection of cells to add to the combinatorial complex.
-    name : str, optional
-        An identifiable name for the combinatorial complex.
     ranks : Collection, optional
         When cells is an iterable or dictionary, ranks cannot be None and it must be iterable/dict of the same
         size as cells.
@@ -74,7 +72,6 @@ class CombinatorialComplex(ColoredHyperGraph):
     def __init__(
         self,
         cells: Collection | None = None,
-        name: str = "",
         ranks: Collection | None = None,
         graph_based: bool = False,
         **kwargs,
@@ -85,8 +82,6 @@ class CombinatorialComplex(ColoredHyperGraph):
         ----------
         cells : Collection, optional
             A collection of cells to add to the combinatorial complex.
-        name : str, optional
-            An identifiable name for the combinatorial complex.
         ranks : Collection, optional
             When cells is an iterable or dictionary, ranks cannot be None and it must be iterable/dict of the same
             size as cells.
@@ -115,7 +110,6 @@ class CombinatorialComplex(ColoredHyperGraph):
         If cells is a NetworkX graph, it adds nodes and edges accordingly.
         """
         Complex.__init__(self, **kwargs)
-        self.name = name
         self.graph_based = graph_based  # rank 1 edges have cardinality equals to 1
         self._node_membership = {}
         self._complex_set = HyperEdgeView()
@@ -172,7 +166,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         str
             Description of Combinatorial Complex.
         """
-        return f"CombinatorialComplex(name='{self.name}')"
+        return "CombinatorialComplex()"
 
     def __setitem__(self, cell, attr):
         """Set the attributes of a hyperedge or node in the CCC.
@@ -1126,7 +1120,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         CombinatorialComplex
             A copy of this combinatorial complex.
         """
-        CCC = CombinatorialComplex(name=self.name, graph_based=self.graph_based)
+        CCC = CombinatorialComplex(graph_based=self.graph_based)
         for cell in self.cells:
             CCC.add_cell(cell, self.cells.get_rank(cell))
         return CCC

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -15,8 +15,6 @@ class Atom(abc.ABC):
     ----------
     elements : Collection[Hashable]
         The elements in the atom.
-    name : str, optional
-        Name of the atom.
     **kwargs : keyword arguments, optional
         Additional attributes to be associated with the atom.
     """
@@ -24,22 +22,17 @@ class Atom(abc.ABC):
     elements: Collection[Hashable]
     name: str
 
-    def __init__(
-        self, elements: Collection[Hashable], name: str = "", **kwargs
-    ) -> None:
+    def __init__(self, elements: Collection[Hashable], **kwargs) -> None:
         """Abstract class representing an atom in a complex.
 
         Parameters
         ----------
         elements : Collection[Hashable]
             The elements in the atom.
-        name : str, optional
-            Name of the atom.
         **kwargs : keyword arguments, optional
             Additional attributes to be associated with the atom.
         """
         self.elements = elements
-        self.name = name
 
         self._attributes = {}
         self._attributes.update(kwargs)
@@ -153,8 +146,6 @@ class Complex(abc.ABC):
 
     Parameters
     ----------
-    name : str, optional
-        Name of the complex.
     **kwargs : keyword arguments, optional
         Attributes to add to the complex as key=value pairs.
 
@@ -166,17 +157,14 @@ class Complex(abc.ABC):
 
     complex: dict[Any, Any]
 
-    def __init__(self, name: str = "", **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
         """Initialize a new instance of the Complex class.
 
         Parameters
         ----------
-        name : str, optional
-            Name of the complex.
         **kwargs : keyword arguments, optional
             Attributes to add to the complex as key=value pairs.
         """
-        self.name = name
         self.complex = {}
         self.complex.update(kwargs)
 

--- a/toponetx/classes/hyperedge.py
+++ b/toponetx/classes/hyperedge.py
@@ -19,8 +19,6 @@ class HyperEdge(Atom):
     ----------
     elements : iterable of hashables
         The nodes in the hyperedge.
-    name : str, optional
-        The name of the hyperedge.
     rank : int, optional
         The rank of the hyperedge. Default is None.
     **kwargs : additional attributes
@@ -34,9 +32,7 @@ class HyperEdge(Atom):
     >>> ac3 = HyperEdge(("a", "b", "c"), rank=10)
     """
 
-    def __init__(
-        self, elements: Collection, name: str = "", rank=None, **kwargs
-    ) -> None:
+    def __init__(self, elements: Collection, rank=None, **kwargs) -> None:
         """Generate instance of the class for a hyperedge (or a set-type cell).
 
         This class represents a set-type cell in a combinatorial complex, which is a set of
@@ -47,8 +43,6 @@ class HyperEdge(Atom):
         ----------
         elements : iterable of hashables
             The nodes in the hyperedge.
-        name : str, optional
-            The name of the hyperedge.
         rank : int, optional
             The rank of the hyperedge. Default is None.
         **kwargs : additional attributes
@@ -65,7 +59,7 @@ class HyperEdge(Atom):
             if not isinstance(i, Hashable):
                 raise TypeError("Every element of HyperEdge must be hashable.")
 
-        super().__init__(frozenset(sorted(elements)), name, **kwargs)
+        super().__init__(frozenset(sorted(elements)), **kwargs)
         if len(elements) != len(self.elements):
             raise ValueError("A hyperedge cannot contain duplicate nodes.")
 

--- a/toponetx/classes/path.py
+++ b/toponetx/classes/path.py
@@ -22,8 +22,6 @@ class Path(Atom):
     ----------
     elements : Sequence[Hashable]
         The nodes in the elementary p-path.
-    name : str, optional
-        A name for the elementary p-path.
     construct_boundaries : bool, default=False
         If True, construct the entire boundary of the elementary p-path.
     reserve_sequence_order : bool, default=False
@@ -76,7 +74,6 @@ class Path(Atom):
     def __init__(
         self,
         elements: Sequence[Hashable] | Hashable,
-        name: str = "",
         construct_boundaries: bool = False,
         reserve_sequence_order: bool = False,
         allowed_paths: Iterable[tuple[Hashable]] | None = None,
@@ -95,8 +92,6 @@ class Path(Atom):
         ----------
         elements : Sequence[Hashable]
             The nodes in the elementary p-path.
-        name : str, optional
-            A name for the elementary p-path.
         construct_boundaries : bool, default=False
             If True, construct the entire boundary of the elementary p-path.
         reserve_sequence_order : bool, default=False
@@ -148,7 +143,7 @@ class Path(Atom):
         self.__check_inputs(elements, reserve_sequence_order)
         if isinstance(elements, (int, str)):
             elements = [elements]
-        super().__init__(tuple(elements), name, **kwargs)
+        super().__init__(tuple(elements), **kwargs)
         if len(set(elements)) != len(self.elements):
             raise ValueError("A p-path cannot contain duplicate nodes.")
 
@@ -237,7 +232,6 @@ class Path(Atom):
         """
         return Path(
             self.elements,
-            name=self.name,
             construct_boundaries=self.construct_boundaries,
             **self._attributes,
         )

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -31,8 +31,6 @@ class PathComplex(Complex):
     ----------
     paths : nx.Graph or Iterable[Sequence[Hashable]]
         The paths in the path complex. If a graph is provided, the path complex will be constructed from the graph, and allowed paths are automatically computed.
-    name : str, optional
-        A name for the path complex.
     reserve_sequence_order : bool, default=False
         If True, reserve the order of the sub-sequence of nodes in the elementary p-path. Else, the sub-sequence of nodes in the elementary p-path will
         be reversed if the first index is larger than the last index.
@@ -84,7 +82,6 @@ class PathComplex(Complex):
     def __init__(
         self,
         paths: nx.Graph | Iterable[Sequence[Hashable] | Path] | None = None,
-        name: str = "",
         reserve_sequence_order: bool = False,
         allowed_paths: Iterable[tuple[Hashable]] | None = None,
         max_rank: int = 3,
@@ -106,8 +103,6 @@ class PathComplex(Complex):
         ----------
         paths : nx.Graph or Iterable[Sequence[Hashable]]
             The paths in the path complex. If a graph is provided, the path complex will be constructed from the graph, and allowed paths are automatically computed.
-        name : str, optional
-            A name for the path complex.
         reserve_sequence_order : bool, default=False
             If True, reserve the order of the sub-sequence of nodes in the elementary p-path. Else, the sub-sequence of nodes in the elementary p-path will
             be reversed if the first index is larger than the last index.
@@ -155,7 +150,7 @@ class PathComplex(Complex):
         >>> PC.paths
         PathView([(1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 3, 2), (1, 2, 3), (2, 1, 3)])
         """
-        super().__init__(name=name, **kwargs)
+        super().__init__(**kwargs)
 
         self._path_set = PathView()
         self._G = nx.Graph()
@@ -392,7 +387,7 @@ class PathComplex(Complex):
         PathComplex
             Returns a copy of the PathComplex.
         """
-        return PathComplex(list(self.paths), name=self.name, rank=self.dim)
+        return PathComplex(list(self.paths), rank=self.dim)
 
     def skeleton(self, rank: int) -> list[tuple[Hashable]]:
         """Compute skeleton.
@@ -764,15 +759,13 @@ class PathComplex(Complex):
             return ind, L_down
         return L_down
 
-    def restrict_to_nodes(self, node_set: Iterable[Hashable], name: str = ""):
+    def restrict_to_nodes(self, node_set: Iterable[Hashable]):
         """Return a new path complex restricted to a subset of nodes.
 
         Parameters
         ----------
         node_set : Iterable[Hashable]
             The nodes to be used for the new restricted path complex.
-        name : str
-            The name of the new path complex to be used.
 
         Returns
         -------
@@ -793,17 +786,15 @@ class PathComplex(Complex):
         for path in self.paths:
             if all(node in node_set for node in path):
                 new_paths.append(path)
-        return PathComplex(new_paths, name=name)
+        return PathComplex(new_paths)
 
-    def restrict_to_paths(self, path_set: Iterable[Sequence[Hashable]], name: str = ""):
+    def restrict_to_paths(self, path_set: Iterable[Sequence[Hashable]]):
         """Return a new path complex restricted to a subset of paths.
 
         Parameters
         ----------
         path_set : Iterable[Sequence[Hashable]]
             The paths to be used for the new restricted path complex.
-        name : str
-            The name of the new path complex to be used.
 
         Returns
         -------
@@ -828,7 +819,7 @@ class PathComplex(Complex):
         for path in self.paths:
             if path in new_path_set:
                 new_paths.append(path)
-        return PathComplex(new_paths, name=name)
+        return PathComplex(new_paths)
 
     def get_node_attributes(self, name: str) -> dict[tuple[Hashable], Any]:
         """Get node attributes from a path complex.
@@ -1230,7 +1221,7 @@ class PathComplex(Complex):
         str
             The __repr__ representation of the Path Complex.
         """
-        return f"PathComplex(name='{self.name}')"
+        return "PathComplex()"
 
     @staticmethod
     def compute_allowed_paths(

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -22,24 +22,10 @@ __all__ = [
 
 
 class CellView:
-    """A CellView class for cells of a CellComplex.
+    """A CellView class for cells of a CellComplex."""
 
-    Parameters
-    ----------
-    name : str, optional
-        The name of the cell view.
-    """
-
-    def __init__(self, name: str = "") -> None:
-        """Initialize an object for the CellView class for cells of a CellComplex.
-
-        Parameters
-        ----------
-        name : str, optional
-            The name of the cell view.
-        """
-        self.name = name
-
+    def __init__(self) -> None:
+        """Initialize an object for the CellView class for cells of a CellComplex."""
         # Initialize a dictionary to hold cells, with keys being the tuple
         # that defines the cell, and values being dictionaries of cell objects
         # with different attributes
@@ -221,29 +207,18 @@ class ColoredHyperEdgeView:
     Provides methods for accessing, and retrieving
     information about the cells/hyperedges of a complex.
 
-    Parameters
-    ----------
-    name : str, optional
-        The name of the view.
-
     Examples
     --------
     >>> hev = ColoredHyperEdgeView()
     """
 
-    def __init__(self, name: str = "") -> None:
+    def __init__(self) -> None:
         """Initialize a new instance of the ColoredHyperEdgeView class.
-
-        Parameters
-        ----------
-        name : str, optional
-            The name of the view.
 
         Examples
         --------
         >>> hev = ColoredHyperEdgeView()
         """
-        self.name = name
         self.hyperedge_dict = {}
 
     def __getitem__(self, hyperedge):
@@ -493,32 +468,21 @@ class HyperEdgeView:
     Provides methods for accessing, and retrieving
     information about the cells/hyperedges of a complex.
 
-    Parameters
-    ----------
-    name : str, optional
-        The name of the view.
-
     Examples
     --------
     >>> hev = HyperEdgeView()
     """
 
-    def __init__(self, name: str = "") -> None:
+    def __init__(self) -> None:
         """Initialize an instance of the class for viewing the cells/hyperedges of a combinatorial complex.
 
         Provides methods for accessing, and retrieving
         information about the cells/hyperedges of a complex.
 
-        Parameters
-        ----------
-        name : str, optional
-            The name of the view.
-
         Examples
         --------
         >>> hev = HyperEdgeView()
         """
-        self.name = name
         self.hyperedge_dict = {}
 
     @staticmethod
@@ -817,11 +781,6 @@ class SimplexView:
     These classes are used in conjunction with the SimplicialComplex class
     for view/read only purposes for simplices in simplicial complexes.
 
-    Parameters
-    ----------
-    name : str, optional
-        Name of the SimplexView instance.
-
     Attributes
     ----------
     max_dim : int
@@ -830,21 +789,14 @@ class SimplexView:
         A list containing dictionaries of faces for each dimension.
     """
 
-    def __init__(self, name: str = "") -> None:
+    def __init__(self) -> None:
         """Initialize an instance of the Simplex View class.
 
         The SimplexView class is used to provide a view/read only information
         into a subset of the nodes in a simplex.
         These classes are used in conjunction with the SimplicialComplex class
         for view/read only purposes for simplices in simplicial complexes.
-
-        Parameters
-        ----------
-        name : str, optional
-            Name of the SimplexView instance.
         """
-        self.name = name
-
         self.max_dim = -1
         self.faces_dict = []
 
@@ -991,13 +943,9 @@ class NodeView:
         The type of the cell.
     colored_nodes : bool, optional
         Whether or not the nodes are colored.
-    name : str, optional
-        Name of the NodeView instance.
     """
 
-    def __init__(
-        self, objectdict, cell_type, colored_nodes: bool = False, name: str = ""
-    ) -> None:
+    def __init__(self, objectdict, cell_type, colored_nodes: bool = False) -> None:
         """Initialize an instance of the Node view class.
 
         Parameters
@@ -1008,10 +956,7 @@ class NodeView:
             The type of the cell.
         colored_nodes : bool, optional, default = False
             Whether or not the nodes are colored.
-        name : str, optional
-            Name of the NodeView instance.
         """
-        self.name = name
         if len(objectdict) != 0:
             self.nodes = objectdict[0]
         else:
@@ -1115,23 +1060,11 @@ class NodeView:
 
 
 class PathView(SimplexView):
-    """Path view class.
+    """Path view class."""
 
-    Parameters
-    ----------
-    name : str, optional
-        Name of the PathView instance.
-    """
-
-    def __init__(self, name: str = "") -> None:
-        """Initialize an instance of the Path view class.
-
-        Parameters
-        ----------
-        name : str, optional
-            Name of the PathView instance.
-        """
-        super().__init__(name)
+    def __init__(self) -> None:
+        """Initialize an instance of the Path view class."""
+        super().__init__()
 
     def __getitem__(self, path: Hashable | Sequence[Hashable] | Path):
         """Get the dictionary of attributes associated with the given path.

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -20,8 +20,6 @@ class Simplex(Atom):
     ----------
     elements : Collection
         The nodes in the simplex.
-    name : str, optional
-        A name for the simplex.
     construct_tree : bool, default=True
         If True, construct the entire simplicial tree for the simplex.
     **kwargs : keyword arguments, optional
@@ -43,7 +41,6 @@ class Simplex(Atom):
     def __init__(
         self,
         elements: Collection,
-        name: str = "",
         construct_tree: bool = False,
         **kwargs,
     ) -> None:
@@ -56,8 +53,6 @@ class Simplex(Atom):
         ----------
         elements : Collection
             The nodes in the simplex.
-        name : str, optional
-            A name for the simplex.
         construct_tree : bool, default=True
             If True, construct the entire simplicial tree for the simplex.
         **kwargs : keyword arguments, optional
@@ -85,7 +80,7 @@ class Simplex(Atom):
             if not isinstance(i, Hashable):
                 raise ValueError(f"All nodes of a simplex must be hashable, got {i}")
 
-        super().__init__(frozenset(sorted(elements)), name, **kwargs)
+        super().__init__(frozenset(sorted(elements)), **kwargs)
         if len(elements) != len(self.elements):
             raise ValueError("A simplex cannot contain duplicate nodes.")
 
@@ -229,4 +224,4 @@ class Simplex(Atom):
         Simplex
             A copy of this simplex.
         """
-        return Simplex(self.elements, name=self.name, **self._attributes)
+        return Simplex(self.elements, **self._attributes)

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -69,8 +69,6 @@ class SimplicialComplex(Complex):
     ----------
     simplices : iterable, optional
         Iterable of maximal simplices that define the simplicial complex.
-    name : str, optional
-        If None then a placeholder '' will be inserted as name.
     **kwargs : keyword arguments, optional
         Attributes to add to the complex as key=value pairs.
 
@@ -105,19 +103,17 @@ class SimplicialComplex(Complex):
     4
     """
 
-    def __init__(self, simplices=None, name: str = "", **kwargs) -> None:
+    def __init__(self, simplices=None, **kwargs) -> None:
         """Initialize the simplicial complex.
 
         Parameters
         ----------
         simplices : iterable, optional
             Iterable of maximal simplices that define the simplicial complex.
-        name : str, optional
-            If None then a placeholder '' will be inserted as name.
         **kwargs : keyword arguments, optional
             Attributes to add to the complex as key=value pairs.
         """
-        super().__init__(name, **kwargs)
+        super().__init__(**kwargs)
 
         self._simplex_set = SimplexView()
 
@@ -296,9 +292,9 @@ class SimplicialComplex(Complex):
         Returns
         -------
         str
-            A string representation containing the name of the simplicial complex.
+            A string representation of the simplicial complex.
         """
-        return f"SimplicialComplex(name='{self.name}')"
+        return "SimplicialComplex()"
 
     def __len__(self) -> int:
         """Compute number of simplices.
@@ -1347,7 +1343,7 @@ class SimplicialComplex(Complex):
 
         self.add_simplices_from(_simplices)
 
-    def restrict_to_simplices(self, cell_set, name: str = "") -> "SimplicialComplex":
+    def restrict_to_simplices(self, cell_set) -> "SimplicialComplex":
         """Construct a simplicial complex using a subset of the simplices.
 
         Parameters
@@ -1355,8 +1351,6 @@ class SimplicialComplex(Complex):
         cell_set : iterable of hashables or simplices
             A subset of elements of the simplicial complex that should be in the new
             simplicial complex.
-        name : str, optional
-            Name of the restricted simplicial complex.
 
         Returns
         -------
@@ -1378,9 +1372,9 @@ class SimplicialComplex(Complex):
             if cell in self:
                 rns.append(cell)
 
-        return SimplicialComplex(simplices=rns, name=name)
+        return SimplicialComplex(simplices=rns)
 
-    def restrict_to_nodes(self, node_set, name: str = ""):
+    def restrict_to_nodes(self, node_set):
         """Construct a new simplicial complex by restricting the simplices.
 
         The simplices are restricted to the nodes referenced by node_set.
@@ -1389,8 +1383,6 @@ class SimplicialComplex(Complex):
         ----------
         node_set : iterable of hashables
             A subset of nodes of the simplicial complex to restrict to.
-        name : str, optional
-            Name of the restricted simplicial complex.
 
         Returns
         -------
@@ -1415,7 +1407,7 @@ class SimplicialComplex(Complex):
                     simplices.append(s)
         all_sim = simplices + [frozenset({i}) for i in node_set if i in self.nodes]
 
-        return SimplicialComplex(all_sim, name=name)
+        return SimplicialComplex(all_sim)
 
     def get_all_maximal_simplices(self):
         """Get all maximal simplices of this simplicial complex.
@@ -1739,7 +1731,7 @@ class SimplicialComplex(Complex):
         >>> SC[(1, 2)]["weight"]
         2
         """
-        return cls(G, name=G.name)
+        return cls(G)
 
     def is_connected(self) -> bool:
         """Check if the simplicial complex is connected.
@@ -1867,4 +1859,4 @@ class SimplicialComplex(Complex):
         SimplicialComplex
             A shallow copy of this simplicial complex.
         """
-        return SimplicialComplex(self.simplices, name=self.name)
+        return SimplicialComplex(self.simplices)


### PR DESCRIPTION
In most cases, some user-defined name can be stored in a complex or atom attribute anyway, there is no need for a separate implementation.