### PR TITLE
Remove hard requirement for `hypernetx`.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11"]
+        flavor: ["dev", "all"]
 
     steps:
       - uses: actions/checkout@v3
@@ -39,9 +40,9 @@ jobs:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
 
-      - name: Install main package [pip]
+      - name: Install Package [${{ matrix.flavor }}]
         run: |
-          pip install -e .[all]
+          pip install -e .[${{ matrix.flavor }}]
 
       - name: Typecheck [mypy]
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies=[
     "gudhi",
     "decorator",
     "networkx",
-    "hypernetx < 2.0.0",
     "numpy",
     "requests",
     "scipy",
@@ -61,6 +60,9 @@ test = [
     "pytest-cov",
     "coverage",
     "jupyter",
+
+    # optional packages that are not required to run the library
+    "hypernetx < 2.0.0",
 
     # mypy and typing stubs
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies=[
     "decorator",
     "networkx",
     "numpy",
+    "pandas",
     "requests",
     "scipy",
     "trimesh",
@@ -61,9 +62,6 @@ test = [
     "coverage",
     "jupyter",
 
-    # optional packages that are not required to run the library
-    "hypernetx < 2.0.0",
-
     # mypy and typing stubs
     "mypy",
     "pandas-stubs",
@@ -71,7 +69,12 @@ test = [
 ]
 
 dev = ["TopoNetX[test, lint]"]
-all = ["TopoNetX[doc, dev]"]
+all = [
+    "TopoNetX[doc, dev]",
+
+    # optional packages that are not required to run the library
+    "hypernetx < 2.0.0"
+]
 
 [project.urls]
 homepage="https://github.com/pyt-team/TopoNetX"

--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -9,6 +9,11 @@ from scipy.sparse import bmat
 from toponetx.classes.cell import Cell
 from toponetx.classes.cell_complex import CellComplex
 
+try:
+    import hypernetx as hnx
+except ImportError:
+    hnx = None
+
 
 class TestCellComplex:
     """Test cell complex class."""
@@ -1077,6 +1082,9 @@ class TestCellComplex:
 
         assert CC.get_edge_attributes("color") == {(1, 2): "red", (2, 3): "blue"}
 
+    @pytest.mark.skipif(
+        hnx is None, reason="Optional dependency 'hypernetx' not installed."
+    )
     def test_to_hypergraph(self):
         """Test the conversion of a cell complex to a hypergraph."""
         CC = CellComplex([[1, 2, 3], [4, 5]])

--- a/test/classes/test_path_complex.py
+++ b/test/classes/test_path_complex.py
@@ -1,6 +1,5 @@
 """Test path complex class."""
 
-import hypernetx as hnx
 import networkx as nx
 import numpy as np
 import pytest

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -1,6 +1,5 @@
 """Test simplicial complex class."""
 
-import hypernetx as hnx
 import networkx as nx
 import numpy as np
 import pytest
@@ -15,6 +14,11 @@ from toponetx.classes.combinatorial_complex import CombinatorialComplex
 from toponetx.classes.simplex import Simplex
 from toponetx.classes.simplicial_complex import SimplicialComplex
 from toponetx.datasets.mesh import stanford_bunny
+
+try:
+    import hypernetx as hnx
+except ImportError:
+    hnx = None
 
 
 class TestSimplicialComplex:
@@ -684,6 +688,9 @@ class TestSimplicialComplex:
         SC = stanford_bunny("simplicial")
         assert SC.is_connected()
 
+    @pytest.mark.skipif(
+        hnx is None, reason="Optional dependency 'hypernetx' not installed."
+    )
     def test_simplicial_closure_of_hypergraph(self):
         """Test simplicial_closure_of_hypergraph."""
         hg = hnx.Hypergraph([[1, 2, 3, 4], [1, 2, 3]], static=True)
@@ -707,6 +714,9 @@ class TestSimplicialComplex:
         ]
         assert len(sc.simplices) == len(expected_simplices)
 
+    @pytest.mark.skipif(
+        hnx is None, reason="Optional dependency 'hypernetx' not installed."
+    )
     def test_to_hypergraph(self):
         """Convert a SimplicialComplex to a hypergraph and compare the number of edges."""
         c1 = Simplex((1, 2, 3))

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -16,8 +16,6 @@ import networkx as nx
 import numpy as np
 import scipy as sp
 import scipy.sparse
-from hypernetx import Hypergraph
-from hypernetx.classes.entity import Entity
 from networkx import Graph
 from networkx.classes.reportviews import EdgeView, NodeView
 from networkx.utils import pairwise
@@ -32,6 +30,13 @@ from toponetx.classes.reportviews import CellView
 from toponetx.utils import incidence_to_adjacency
 
 __all__ = ["CellComplex"]
+
+try:
+    from hypernetx import Hypergraph
+    from hypernetx.classes.entity import Entity
+except ImportError:
+    Hypergraph = None
+    Entity = None
 
 
 class CellComplex(Complex):

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -11,12 +11,16 @@ from warnings import warn
 import networkx as nx
 import numpy as np
 from gudhi import SimplexTree
-from hypernetx import Hypergraph
 from scipy.sparse import csr_matrix, dok_matrix
 
 from toponetx.classes.complex import Complex
 from toponetx.classes.reportviews import NodeView, SimplexView
 from toponetx.classes.simplex import Simplex
+
+try:
+    from hypernetx import Hypergraph
+except ImportError:
+    Hypergraph = None
 
 __all__ = ["SimplicialComplex"]
 
@@ -1132,7 +1136,7 @@ class SimplicialComplex(Complex):
         m, n = L_hodge.shape
         diags_ = abs(L_hodge).sum(axis=1)
 
-        with sp.errstate(divide="ignore"):
+        with np.errstate(divide="ignore"):
             diags_sqrt = 1.0 / np.sqrt(diags_)
         diags_sqrt[np.isinf(diags_sqrt)] = 0
         diags_sqrt = sp.sparse.csr_array(


### PR DESCRIPTION
The requirement on HyperNetX is not hard and is problematic, as it is not compatible with NetworkX 3, which is more than a year old. With this pull request, users that do not use hypergraphs are free to use NetworkX 3, while others must stay on NetworkX 2 (as transient dependency due to HyperNetX).

We exclusively use HyperNetX in places where we transform user-provided hypergraph instances into complex classes or vice versa. Such code points are only ever called when the user itself interacts with HyperNetX and thus did install it themself. We don't need to force that dependency.