### PR TITLE
Activate more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ select = [
     "B", # bugbear rules
     "PIE", # pie rules
     "Q", # quote rules
+    "RET", # return rules
     "SIM", # code simplifications
 ]
 ignore = ["E501"] # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ select = [
     "Q", # quote rules
     "RET", # return rules
     "SIM", # code simplifications
+    "NPY", # numpy rules
 ]
 ignore = ["E501"] # line too long
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ select = [
     "W", # warnings
     "I", # import order
     "UP", # pyupgrade rules
+    "B", # bugbear rules
     "SIM", # code simplifications
 ]
 ignore = ["E501"] # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ select = [
     "SIM", # code simplifications
     "NPY", # numpy rules
     "PERF", # performance rules
+    "RUF", # miscellaneous rules
 ]
 ignore = [
     "E501",    # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ select = [
     "I", # import order
     "UP", # pyupgrade rules
     "B", # bugbear rules
+    "PIE", # pie rules
     "SIM", # code simplifications
 ]
 ignore = ["E501"] # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ select = [
     "UP", # pyupgrade rules
     "B", # bugbear rules
     "PIE", # pie rules
+    "Q", # quote rules
     "SIM", # code simplifications
 ]
 ignore = ["E501"] # line too long

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,12 @@ select = [
     "RET", # return rules
     "SIM", # code simplifications
     "NPY", # numpy rules
+    "PERF", # performance rules
 ]
-ignore = ["E501"] # line too long
+ignore = [
+    "E501",    # line too long
+    "PERF203", # allow try-except within loops
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/test/classes/test_cell.py
+++ b/test/classes/test_cell.py
@@ -80,7 +80,7 @@ class TestCell:
     def test___iter__(self):
         """Test __iter__."""
         c = Cell([1, 2, 3])
-        for i in c:
+        for _ in c:
             pass
 
     def test___repr__(self):

--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -1361,12 +1361,12 @@ class TestCellComplex:
         """Test the get_cell_data method of CellComplex."""
         CC = CellComplex()
 
-        CC.add_node("A", **{"attribute_name": "Value A"})
-        CC.add_node("B", **{"attribute_name": "Value B"})
+        CC.add_node("A", attribute_name="Value A")
+        CC.add_node("B", attribute_name="Value B")
 
-        CC.add_edge("A", "B", **{"attribute_name": "Value AB"})
+        CC.add_edge("A", "B", attribute_name="Value AB")
 
-        CC.add_cell(["A", "B", "C"], rank=2, **{"attribute_name": "Value C"})
+        CC.add_cell(["A", "B", "C"], rank=2, attribute_name="Value C")
 
         data = CC.get_cell_data("A", 0, "attribute_name")
         assert data == "Value A"
@@ -1446,7 +1446,7 @@ class TestCellComplex:
         CC = CellComplex()
 
         CC.add_node("A")
-        CC.add_node("B", **{"attribute_name": "Value B"})
+        CC.add_node("B", attribute_name="Value B")
 
         data = CC.get_cell_data("A", 0)
         assert len(data) == 0

--- a/test/classes/test_combinatorial_complex.py
+++ b/test/classes/test_combinatorial_complex.py
@@ -513,7 +513,7 @@ class TestCombinatorialComplex:
         d = {node: {"color": "red", "attr2": 1}}
         example1.set_node_attributes(d)
         assert example1.nodes.nodes[frozenset({node})]["color"] == "red"
-        example1.get_node_attributes("color") == {4: "red"}
+        assert example1.get_node_attributes("color") == {4: "red"}
         node = 6
         d = {node: "red"}
         example1.set_node_attributes(d, "color")
@@ -539,7 +539,7 @@ class TestCombinatorialComplex:
         }
         with pytest.raises(ValueError) as exp:
             CCC.add_cells_from([[1, 4]], ranks=[1, 1])
-        assert str(exp.value) == "cells and ranks must have equal number of elements"
+        assert str(exp.value) == "zip() argument 2 is longer than argument 1"
         CCC = CombinatorialComplex()
         CCC.add_cells_from(
             [

--- a/test/classes/test_reportviews.py
+++ b/test/classes/test_reportviews.py
@@ -370,7 +370,7 @@ class TestReportViews_HyperEdgeView:
 
         assert (
             str(exp_exception.value)
-            == "level must be 'equal', 'uppereq', 'lowereq', 'upeq', 'downeq', 'uppereq', 'lower', 'up', or 'down'  "
+            == "level must be 'equal', 'uppereq', 'lowereq', 'upeq', 'downeq', 'uppereq', 'lower', 'up', or 'down'"
         )
 
     def test_hyper_edge_view_get_rank(self):

--- a/toponetx/algorithms/components.py
+++ b/toponetx/algorithms/components.py
@@ -145,10 +145,8 @@ def s_component_subcomplexes(
     >>> CC.add_cell([4, 5], rank=1)
     >>> list(s_component_subcomplexes(CC, s=1, cells=False))
     """
-    for idx, c in enumerate(
-        s_connected_components(
-            domain, s=s, cells=cells, return_singletons=return_singletons
-        )
+    for c in s_connected_components(
+        domain, s=s, cells=cells, return_singletons=return_singletons
     ):
         if cells:
             yield domain.restrict_to_cells(list(c))

--- a/toponetx/algorithms/components.py
+++ b/toponetx/algorithms/components.py
@@ -103,7 +103,7 @@ def s_connected_components(
             if isinstance(domain, CellComplex):
                 yield {node_dict[n] for n in c}
             else:
-                yield {tuple(node_dict[n])[0] for n in c}
+                yield {next(iter(node_dict[n])) for n in c}
 
 
 def s_component_subcomplexes(

--- a/toponetx/algorithms/distance.py
+++ b/toponetx/algorithms/distance.py
@@ -77,7 +77,7 @@ def distance(domain: Complex, source: Hashable, target: Hashable, s: int = 1) ->
         path = nx.shortest_path_length(G, rowdict[source], rowdict[target])
         return path
     except Exception:
-        warn(f"No {s}-path between {source} and {target}")
+        warn(f"No {s}-path between {source} and {target}", stacklevel=2)
         return np.inf
 
 
@@ -153,5 +153,5 @@ def cell_distance(
         path_distance = nx.shortest_path_length(G, cell_dict[source], cell_dict[target])
         return path_distance
     except Exception:
-        warn(f"No {s}-path between {source} and {target}")
+        warn(f"No {s}-path between {source} and {target}", stacklevel=2)
         return np.inf

--- a/toponetx/algorithms/distance.py
+++ b/toponetx/algorithms/distance.py
@@ -74,8 +74,7 @@ def distance(domain: Complex, source: Hashable, target: Hashable, s: int = 1) ->
     rowdict, A = domain.node_to_all_cell_adjacnecy_matrix(index=True)
     G = nx.from_scipy_sparse_array(A)
     try:
-        path = nx.shortest_path_length(G, rowdict[source], rowdict[target])
-        return path
+        return nx.shortest_path_length(G, rowdict[source], rowdict[target])
     except Exception:
         warn(f"No {s}-path between {source} and {target}", stacklevel=2)
         return np.inf
@@ -150,8 +149,7 @@ def cell_distance(
     cell_dict, A = domain.all_cell_to_node_coadjacency_matrix(s=s, index=True)
     G = nx.from_scipy_sparse_array(A)
     try:
-        path_distance = nx.shortest_path_length(G, cell_dict[source], cell_dict[target])
-        return path_distance
+        return nx.shortest_path_length(G, cell_dict[source], cell_dict[target])
     except Exception:
         warn(f"No {s}-path between {source} and {target}", stacklevel=2)
         return np.inf

--- a/toponetx/algorithms/distance_measures.py
+++ b/toponetx/algorithms/distance_measures.py
@@ -151,7 +151,7 @@ def diameter(domain: Complex) -> int:
     raise RuntimeError("cc is not connected.")
 
 
-def cell_diameter(domain: Complex, s: int = None) -> int:
+def cell_diameter(domain: Complex, s: int | None = None) -> int:
     """Return the length of the longest shortest s-walk between cells.
 
     Parameters

--- a/toponetx/algorithms/spectrum.py
+++ b/toponetx/algorithms/spectrum.py
@@ -136,7 +136,7 @@ def set_hodge_laplacian_eigenvector_attrs(
     _, vect = hodge_laplacian_eigenvectors(L, n_components)
 
     for i in range(len(vect)):
-        d = dict(zip(index, vect[i]))
+        d = dict(zip(index, vect[i], strict=True))
         if normalized:
             d = _normalize(d)
         SC.set_simplex_attributes(d, str(i) + ".th_eigen")
@@ -190,7 +190,7 @@ def set_laplacian_beltrami_eigenvectors(SC: SimplicialComplex) -> None:
     index = SC.skeleton(0)
     vect, _ = laplacian_beltrami_eigenvectors(SC)
     for i in range(len(vect)):
-        d = dict(zip(index, vect[:, i]))
+        d = dict(zip(index, vect[:, i], strict=True))
         SC.set_simplex_attributes(d, str(i) + ".laplacian_beltrami_eigenvectors")
 
 

--- a/toponetx/algorithms/spectrum.py
+++ b/toponetx/algorithms/spectrum.py
@@ -86,7 +86,7 @@ def hodge_laplacian_eigenvectors(
     eigenvaluevector = [round(i, 15) for i in vals.real]
     eigenvectorstemp = vect.transpose().real
     mydict = {}
-    for i in range(0, len(eigenvaluevector)):
+    for i in range(len(eigenvaluevector)):
         mydict[eigenvaluevector[i]] = eigenvectorstemp[i]
     eigenvaluevector.sort()
     finaleigenvectors = [mydict[val] for val in eigenvaluevector]

--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -105,9 +105,9 @@ class Cell(Atom):
     def clone(self) -> "Cell":
         """Clone the Cell with all attributes.
 
-        The clone method by default returns an independent shallow copy of the cell and attributes. That is, if an
-        attribute is a container, that container is shared by the original and the copy. Use Python’s `copy.deepcopy`
-        for new containers.
+        The clone method by default returns an independent shallow copy of the cell and
+        attributes. That is, if an attribute is a container, that container is shared
+        by the original and the copy. Use Python's `copy.deepcopy` for new containers.
 
         Returns
         -------

--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -162,12 +162,12 @@ class Cell(Atom):
         """
         if self._regular:  # condition enforced
             return True
-        else:
-            _adjdict = {}
-            for e in self._boundary:
-                if e[0] in _adjdict:
-                    return False
-                _adjdict[e[0]] = e[1]
+
+        _adjdict = {}
+        for e in self._boundary:
+            if e[0] in _adjdict:
+                return False
+            _adjdict[e[0]] = e[1]
 
         return True
 
@@ -208,10 +208,9 @@ class Cell(Atom):
         if len(edge) == 2:
             if tuple(edge) in self.boundary:
                 return 1
-            elif tuple(edge)[::-1] in self.boundary:
+            if tuple(edge)[::-1] in self.boundary:
                 return -1
-            else:
-                raise KeyError(f"Ihe input {edge} is not in the boundary of the cell.")
+            raise KeyError(f"Ihe input {edge} is not in the boundary of the cell.")
 
         raise ValueError(f"The input {edge} is not a valid edge.")
 

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -1164,10 +1164,8 @@ class CellComplex(Complex):
                                 self.cells[cell][i][name] = value
                         else:
                             self.cells[cell][name] = value
-
                     except KeyError:
                         pass
-
             else:
                 for cell, d in values.items():
                     try:
@@ -2161,10 +2159,7 @@ class CellComplex(Complex):
         """
         _G = Graph(self._G.subgraph(node_set))
         CC = CellComplex(_G)
-        cells = []
-        for cell in self.cells:
-            if CC.is_insertable_cycle(cell, True):
-                cells.append(cell)
+        cells = [cell for cell in self.cells if CC.is_insertable_cycle(cell, True)]
         CC = CellComplex(_G)
 
         for cell in cells:
@@ -2255,23 +2250,24 @@ class CellComplex(Complex):
         from hypernetx.classes.entity import EntitySet
 
         cells = []
-        for cell in self.cells:
-            cells.append(
-                Entity(
-                    str(list(cell.elements)),
-                    elements=cell.elements,
-                    **self.get_cell_data(cell, 2),
-                )
+        cells.extend(
+            Entity(
+                str(list(cell.elements)),
+                elements=cell.elements,
+                **self.get_cell_data(cell, 2),
             )
-        for cell in self.edges:
-            cells.append(
-                Entity(str(list(cell)), elements=cell, **self.get_cell_data(cell, 1))
-            )
+            for cell in self.cells
+        )
+        cells.extend(
+            Entity(str(list(cell)), elements=cell, **self.get_cell_data(cell, 1))
+            for cell in self.edges
+        )
         E = EntitySet("CX_to_HG", elements=cells)
         HG = Hypergraph(E)
-        nodes = []
-        for cell in self.nodes:
-            nodes.append(Entity(cell, elements=[], **self.get_cell_data(cell, 0)))
+        nodes = [
+            Entity(cell, elements=[], **self.get_cell_data(cell, 0))
+            for cell in self.nodes
+        ]
         HG._add_nodes_from(nodes)
         return HG
 

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -486,8 +486,7 @@ class CellComplex(Complex):
                     for k in d_c:
                         if len(d) == 1:
                             break
-                        else:
-                            self._delete_cell(c, k)
+                        self._delete_cell(c, k)
 
     def degree(self, node: Hashable, rank: int = 1) -> int:
         """Compute the number of cells of certain rank that contain node.
@@ -534,14 +533,13 @@ class CellComplex(Complex):
         if node_set:
             if isinstance(cell, Cell):
                 return len(set(node_set).intersection(set(cell.elements)))
-            elif isinstance(cell, Iterable):
+            if isinstance(cell, Iterable):
                 return len(set(node_set).intersection(set(cell)))
+            return None
 
-        else:
-            if cell in self.cells:
-                return len(cell)
-            else:
-                raise KeyError(f" the key {cell} is not a key for an existing cell ")
+        if cell in self.cells:
+            return len(cell)
+        raise KeyError(f" the key {cell} is not a key for an existing cell ")
 
     def number_of_nodes(self, node_set: Iterable[Hashable] | None = None):
         """Compute number of nodes in node_set belonging to cell complex.
@@ -558,8 +556,7 @@ class CellComplex(Complex):
         """
         if node_set:
             return len([node for node in self.nodes if node in node_set])
-        else:
-            return len(self.nodes)
+        return len(self.nodes)
 
     def number_of_edges(self, edge_set: Iterable[tuple] | None = None) -> int:
         """Compute number of edges in edge_set belonging to cell complex.
@@ -582,8 +579,7 @@ class CellComplex(Complex):
                     if edge in edge_set or edge[::-1] in edge_set
                 ]
             )
-        else:
-            return len(self.edges)
+        return len(self.edges)
 
     def number_of_cells(
         self, cell_set: Iterable[tuple | list | Cell] | None = None
@@ -603,8 +599,7 @@ class CellComplex(Complex):
         """
         if cell_set:
             return len([cell for cell in self.cells if cell in cell_set])
-        else:
-            return len(self.cells)
+        return len(self.cells)
 
     def order(self) -> int:
         """Compute the number of nodes in the cell complex.
@@ -800,14 +795,12 @@ class CellComplex(Complex):
                 raise RuntimeError(
                     "Use `add_node` to insert nodes or zero ranked cells."
                 )
-            elif rank == 1:
+            if rank == 1:
                 if len(cell) != 2:
                     raise ValueError("rank 1 cells (edges) must have exactly two nodes")
                 if len(set(cell)) == 1:
                     raise ValueError(" invalid insertion : self-loops are not allowed.")
-                else:
-                    self.add_edge(cell[0], cell[1], **attr)
-
+                self.add_edge(cell[0], cell[1], **attr)
             elif rank == 2:
                 if isinstance(cell, Iterable):
                     if not isinstance(cell, list):
@@ -1337,19 +1330,15 @@ class CellComplex(Complex):
                 raise KeyError(
                     f"Node '{cell}' does not have an attribute with key {attr_name}."
                 )
+            return container[cell]
 
-            else:
-                return container[cell]
-
-        else:
-            if rank == 0:
-                raise KeyError(f"Node '{cell}' is not present in the complex.")
-            elif rank == 1:
-                raise KeyError(
-                    f"Edge '{cell}' is not present in the complex or does not have two nodes."
-                )
-            else:
-                raise KeyError(f"Cell '{cell}' is not present in the complex.")
+        if rank == 0:
+            raise KeyError(f"Node '{cell}' is not present in the complex.")
+        if rank == 1:
+            raise KeyError(
+                f"Edge '{cell}' is not present in the complex or does not have two nodes."
+            )
+        raise KeyError(f"Cell '{cell}' is not present in the complex.")
 
     def remove_equivalent_cells(self) -> None:
         """Remove equivalent cells.
@@ -1467,8 +1456,7 @@ class CellComplex(Complex):
                     A[ni, cj] = 1
         if index:
             return node_index, all_cell_index, A.asformat("csc")
-        else:
-            return A.asformat("csc")
+        return A.asformat("csc")
 
     def node_to_all_cell_adjacnecy_matrix(
         self, s: int | None = None, weight: str | None = None, index: bool = False
@@ -1522,10 +1510,10 @@ class CellComplex(Complex):
             )
 
             return node_index, incidence_to_adjacency(M.T, s)
-        else:
-            return incidence_to_adjacency(
-                self.node_to_all_cell_incidence_matrix(weight, index).T, s
-            )
+
+        return incidence_to_adjacency(
+            self.node_to_all_cell_incidence_matrix(weight, index).T, s
+        )
 
     def all_cell_to_node_coadjacency_matrix(
         self, s: int | None = None, weight: str | None = None, index: bool = False
@@ -1569,10 +1557,10 @@ class CellComplex(Complex):
             )
 
             return cell_index, incidence_to_adjacency(M, s)
-        else:
-            return incidence_to_adjacency(
-                self.node_to_all_cell_incidence_matrix(weight, index), s
-            )
+
+        return incidence_to_adjacency(
+            self.node_to_all_cell_incidence_matrix(weight, index), s
+        )
 
     def incidence_matrix(
         self,
@@ -1656,15 +1644,13 @@ class CellComplex(Complex):
                 node_index = {node: i for i, node in enumerate(sorted(self._G.nodes))}
                 if signed:
                     return {}, node_index, A.asformat("csr")
-                else:
-                    return {}, node_index, abs(A.asformat("csr"))
-            else:
-                if signed:
-                    return A.asformat("csr")
-                else:
-                    return abs(A.asformat("csr"))
+                return {}, node_index, abs(A.asformat("csr"))
 
-        elif rank == 1:
+            if signed:
+                return A.asformat("csr")
+            return abs(A.asformat("csr"))
+
+        if rank == 1:
             nodelist = sorted(
                 self._G.nodes
             )  # always output boundary matrix in dictionary order
@@ -1681,14 +1667,12 @@ class CellComplex(Complex):
                 edge_index = {tuple(sorted(edge)): i for i, edge in enumerate(edgelist)}
                 if signed:
                     return node_index, edge_index, A.asformat("csr")
-                else:
-                    return node_index, edge_index, abs(A.asformat("csr"))
-            else:
-                if signed:
-                    return A.asformat("csr")
-                else:
-                    return abs(A.asformat("csr"))
-        elif rank == 2:
+                return node_index, edge_index, abs(A.asformat("csr"))
+
+            if signed:
+                return A.asformat("csr")
+            return abs(A.asformat("csr"))
+        if rank == 2:
             edgelist = sorted([sorted(e) for e in self._G.edges])
 
             A = sp.sparse.lil_matrix((len(edgelist), len(self.cells)))
@@ -1724,15 +1708,12 @@ class CellComplex(Complex):
                 cell_index = {c.elements: i for i, c in enumerate(self.cells)}
                 if signed:
                     return edge_index, cell_index, A.asformat("csr")
-                else:
-                    return edge_index, cell_index, abs(A.asformat("csr"))
-            else:
-                if signed:
-                    return A.asformat("csr")
-                else:
-                    return abs(A.asformat("csr"))
-        else:
-            raise ValueError(f"Only dimensions 0, 1 and 2 are supported, got {rank}.")
+                return edge_index, cell_index, abs(A.asformat("csr"))
+
+            if signed:
+                return A.asformat("csr")
+            return abs(A.asformat("csr"))
+        raise ValueError(f"Only dimensions 0, 1 and 2 are supported, got {rank}.")
 
     def hodge_laplacian_matrix(
         self,
@@ -1779,16 +1760,14 @@ class CellComplex(Complex):
                 L_hodge = B_next @ B_next.transpose()
                 if signed:
                     return nodelist, L_hodge
-                else:
-                    return nodelist, abs(L_hodge)
-            else:
-                B_next = self.incidence_matrix(rank + 1, weight=weight)
-                L_hodge = B_next @ B_next.transpose()
-                if signed:
-                    return L_hodge
-                else:
-                    return abs(L_hodge)
-        elif rank < 2:  # rank == 1, return L1
+                return nodelist, abs(L_hodge)
+
+            B_next = self.incidence_matrix(rank + 1, weight=weight)
+            L_hodge = B_next @ B_next.transpose()
+            if signed:
+                return L_hodge
+            return abs(L_hodge)
+        if rank < 2:  # rank == 1, return L1
             if self.dim == 2:
                 edge_list, cell_list, B_next = self.incidence_matrix(
                     rank + 1, weight=weight, index=True
@@ -1802,10 +1781,9 @@ class CellComplex(Complex):
                 L_hodge = abs(L_hodge)
             if index:
                 return edge_list, L_hodge
-            else:
-                return L_hodge
+            return L_hodge
 
-        elif rank == 2 and self.dim == 2:
+        if rank == 2 and self.dim == 2:
             edge_list, cell_list, B = self.incidence_matrix(
                 rank, weight=weight, index=True
             )
@@ -1815,17 +1793,16 @@ class CellComplex(Complex):
 
             if index:
                 return cell_list, L_hodge
-            else:
-                return L_hodge
-        elif rank == 2 and self.dim != 2:
+            return L_hodge
+        if rank == 2 and self.dim != 2:
             raise ValueError(
                 "The input complex does not have cells of dim 2. "
                 f"The maximal cell dimension is {self.dim}, got {rank}"
             )
-        else:
-            raise ValueError(
-                f"Rank should be larger than 0 and <= {self.dim} (maximal dimension cells), got {rank}."
-            )
+
+        raise ValueError(
+            f"Rank should be larger than 0 and <= {self.dim} (maximal dimension cells), got {rank}."
+        )
 
     def up_laplacian_matrix(
         self,
@@ -1889,8 +1866,7 @@ class CellComplex(Complex):
 
         if index:
             return row, L_up
-        else:
-            return L_up
+        return L_up
 
     def down_laplacian_matrix(
         self,
@@ -1947,8 +1923,7 @@ class CellComplex(Complex):
             L_down = abs(L_down)
         if index:
             return row, L_down
-        else:
-            return L_down
+        return L_down
 
     def adjacency_matrix(
         self,
@@ -1991,8 +1966,7 @@ class CellComplex(Complex):
 
         if index:
             return ind, incidence_to_adjacency(incidence)
-        else:
-            return incidence_to_adjacency(incidence)
+        return incidence_to_adjacency(incidence)
 
     def coadjacency_matrix(
         self,
@@ -2027,9 +2001,9 @@ class CellComplex(Complex):
         if index:
             _, ind, incidence = self.incidence_matrix(rank, signed=signed, index=True)
             return ind, incidence_to_adjacency(incidence)
-        else:
-            incidence = self.incidence_matrix(rank, signed=signed)
-            return incidence_to_adjacency(incidence)
+
+        incidence = self.incidence_matrix(rank, signed=signed)
+        return incidence_to_adjacency(incidence)
 
     def dirac_operator_matrix(
         self,
@@ -2083,12 +2057,10 @@ class CellComplex(Complex):
             d.update(index2)
             if signed:
                 return d, dirac
-            else:
-                return d, abs(dirac)
+            return d, abs(dirac)
         if signed:
             return dirac
-        else:
-            return abs(dirac)
+        return abs(dirac)
 
     def restrict_to_cells(
         self,

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -167,7 +167,7 @@ class CellComplex(Complex):
                         if len(cell) == 2:
                             self.add_cell(cell, rank=1)
                         elif len(cell) == 1:
-                            self.add_node(tuple(cell)[0])
+                            self.add_node(next(iter(cell)))
                         else:
                             self.add_cell(cell, rank=2)
 

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -817,8 +817,7 @@ class CellComplex(Complex):
                         cell, check_skeleton=check_skeleton, warnings_dis=True
                     ):
                         edges_cell = set(zip_longest(cell, cell[1:] + [cell[0]]))
-                        for edge in edges_cell:
-                            self._G.add_edges_from(edges_cell)
+                        self._G.add_edges_from(edges_cell)
                         self._insert_cell(Cell(cell, regular=self._regular), **attr)
                     else:
                         raise ValueError(
@@ -1416,7 +1415,8 @@ class CellComplex(Complex):
         if self._regular and len(set(cell)) != len(cell):
             if warnings_dis:
                 warnings.warn(
-                    "repeating nodes invalidates the 2-cell regularity condition"
+                    "repeating nodes invalidates the 2-cell regularity condition",
+                    stacklevel=2,
                 )
             return False
         if check_skeleton:
@@ -2495,7 +2495,13 @@ class CellComplex(Complex):
         first_ind = np.min(mesh.faces)
 
         CC.set_cell_attributes(
-            dict(zip(range(first_ind, len(mesh.vertices) + first_ind), mesh.vertices)),
+            dict(
+                zip(
+                    range(first_ind, len(mesh.vertices) + first_ind),
+                    mesh.vertices,
+                    strict=False,
+                )
+            ),
             name="position",
             rank=0,
         )

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -435,28 +435,26 @@ class ColoredHyperGraph(Complex):
                             if len(x) >= s
                         ]
                     )
-                else:
-                    raise RuntimeError(
-                        f"There are no cells in the colored hypergraph with rank {rank}"
-                    )
 
-            else:
-                raise ValueError("Rank must be positive")
-        elif rank is None:
+                raise RuntimeError(
+                    f"There are no cells in the colored hypergraph with rank {rank}"
+                )
+
+            raise ValueError("Rank must be positive")
+        if rank is None:
             rank_list = self._complex_set.hyperedge_dict.keys()
             value = 0
             for rank in rank_list:
                 if rank == 0:
                     continue
-                else:
-                    value += sum(
-                        len(self._complex_set.hyperedge_dict[rank][x])
-                        if node in x
-                        else 0
-                        for x in self._complex_set.hyperedge_dict[rank]
-                        if len(x) >= s
-                    )
+
+                value += sum(
+                    len(self._complex_set.hyperedge_dict[rank][x]) if node in x else 0
+                    for x in self._complex_set.hyperedge_dict[rank]
+                    if len(x) >= s
+                )
             return value
+        return None
 
     def _remove_node(self, node) -> None:
         """Remove a node from the ColoredHyperGraph.
@@ -848,12 +846,12 @@ class ColoredHyperGraph(Complex):
                 for cell in self.skeleton(rank)
                 if name in self.skeleton(rank)[cell]
             }
-        else:
-            return {
-                cell: self.cells[cell][name]
-                for cell in self.cells
-                if name in self.cells[cell]
-            }
+
+        return {
+            cell: self.cells[cell][name]
+            for cell in self.cells
+            if name in self.cells[cell]
+        }
 
     def _add_nodes_of_hyperedge(self, hyperedge_) -> None:
         """Add nodes of a hyperedge to the CHG.
@@ -1299,8 +1297,7 @@ class ColoredHyperGraph(Complex):
         if index:
             A = incidence_to_adjacency(B[-1], s=s)
             return B[1], A
-        A = incidence_to_adjacency(B, s=s)
-        return A
+        return incidence_to_adjacency(B, s=s)
 
     def node_to_all_cell_adjacnecy_matrix(self, index: bool = False, s: int = None):
         """Compute the node/all cell adjacency matrix.
@@ -1323,8 +1320,7 @@ class ColoredHyperGraph(Complex):
         if index:
             A = incidence_to_adjacency(B[-1].T, s=s)
             return B[0], A
-        A = incidence_to_adjacency(B.T, s=s)
-        return A
+        return incidence_to_adjacency(B.T, s=s)
 
     def coadjacency_matrix(self, rank, via_rank, s: int = 1, index: bool = False):
         """Compute the coadjacency matrix.

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -1544,9 +1544,9 @@ class ColoredHyperGraph(Complex):
         for cell in self.cells:
             zero_elements = cell[0]
             if len(zero_elements) == 1:
-                for n in zero_elements:
-                    if self.degree(n, None) == 1:
-                        singletons.append(cell)
+                singletons.extend(
+                    cell for n in zero_elements if self.degree(n, None) == 1
+                )
         return singletons
 
     def remove_singletons(self):

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -118,13 +118,8 @@ class ColoredHyperGraph(Complex):
                             self.add_cell(cell, rank=cell.rank)
                 else:
                     if isinstance(cells, Iterable) and isinstance(ranks, Iterable):
-                        if len(cells) != len(ranks):
-                            raise ValueError(
-                                "cells and ranks must have equal number of elements"
-                            )
-                        else:
-                            for cell, color in zip(cells, ranks):
-                                self.add_cell(cell, color)
+                        for cell, color in zip(cells, ranks, strict=True):
+                            self.add_cell(cell, color)
                 if isinstance(cells, Iterable) and isinstance(ranks, int):
                     for cell in cells:
                         self.add_cell(cell, ranks)
@@ -998,13 +993,8 @@ class ColoredHyperGraph(Complex):
                     self.add_cell(cell, rank=None)
         else:
             if isinstance(cells, Iterable) and isinstance(ranks, Iterable):
-                if len(cells) != len(ranks):
-                    raise ValueError(
-                        "cells and ranks must have equal number of elements"
-                    )
-                else:
-                    for cell, rank in zip(cells, ranks):
-                        self.add_cell(cell, rank)
+                for cell, rank in zip(cells, ranks, strict=True):
+                    self.add_cell(cell, rank)
         if isinstance(cells, Iterable) and isinstance(ranks, int):
             for cell in cells:
                 self.add_cell(cell, ranks)

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -518,7 +518,7 @@ class ColoredHyperGraph(Complex):
         for node in node_set:
             if isinstance(node, Hashable):
                 if isinstance(node, HyperEdge):
-                    copy_set.add(list(node.elements)[0])
+                    copy_set.add(next(iter(node.elements)))
                 else:
                     copy_set.add(node)
                 if node not in self.nodes:
@@ -806,7 +806,7 @@ class ColoredHyperGraph(Complex):
         'blue'
         """
         return {
-            tuple(node)[0]: self.nodes[node][name]
+            next(iter(node)): self.nodes[node][name]
             for node in self.nodes
             if name in self.nodes[node]
         }
@@ -1075,7 +1075,7 @@ class ColoredHyperGraph(Complex):
         self,
         rank,
         to_rank,
-        weight: bool = None,
+        weight: bool | None = None,
         sparse: bool = True,
         index: bool = False,
     ):
@@ -1276,7 +1276,9 @@ class ColoredHyperGraph(Complex):
 
         return A
 
-    def all_cell_to_node_coadjacency_matrix(self, index: bool = False, s: int = None):
+    def all_cell_to_node_coadjacency_matrix(
+        self, index: bool = False, s: int | None = None
+    ):
         """Compute the cell co-adjacency matrix.
 
         Parameters
@@ -1299,7 +1301,9 @@ class ColoredHyperGraph(Complex):
             return B[1], A
         return incidence_to_adjacency(B, s=s)
 
-    def node_to_all_cell_adjacnecy_matrix(self, index: bool = False, s: int = None):
+    def node_to_all_cell_adjacnecy_matrix(
+        self, index: bool = False, s: int | None = None
+    ):
         """Compute the node/all cell adjacency matrix.
 
         Parameters
@@ -1563,9 +1567,10 @@ class ColoredHyperGraph(Complex):
     def clone(self) -> "ColoredHyperGraph":
         """Return a copy of the simplex.
 
-        The clone method by default returns an independent shallow copy of the simplex and attributes. That is, if an
-        attribute is a container, that container is shared by the original and the copy. Use Python’s `copy.deepcopy`
-        for new containers.
+        The clone method by default returns an independent shallow copy of the simplex
+        and attributes. That is, if an attribute is a container, that container is
+        shared by the original and the copy. Use Python's `copy.deepcopy` for new
+        containers.
 
         Returns
         -------

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -131,13 +131,8 @@ class CombinatorialComplex(ColoredHyperGraph):
                         self.add_cell(cell, rank=cell.rank)
                 else:
                     if isinstance(cells, Iterable) and isinstance(ranks, Iterable):
-                        if len(cells) != len(ranks):
-                            raise ValueError(
-                                "cells and ranks must have equal number of elements"
-                            )
-                        else:
-                            for cell, rank in zip(cells, ranks):
-                                self.add_cell(cell, rank)
+                        for cell, rank in zip(cells, ranks, strict=True):
+                            self.add_cell(cell, rank)
                 if isinstance(cells, Iterable) and isinstance(ranks, int):
                     for cell in cells:
                         self.add_cell(cell, ranks)
@@ -1015,13 +1010,8 @@ class CombinatorialComplex(ColoredHyperGraph):
                 self.add_cell(cell, cell.rank)
         else:
             if isinstance(cells, Iterable) and isinstance(ranks, Iterable):
-                if len(cells) != len(ranks):
-                    raise ValueError(
-                        "cells and ranks must have equal number of elements"
-                    )
-                else:
-                    for cell, rank in zip(cells, ranks):
-                        self.add_cell(cell, rank)
+                for cell, rank in zip(cells, ranks, strict=True):
+                    self.add_cell(cell, rank)
         if isinstance(cells, Iterable) and isinstance(ranks, int):
             for cell in cells:
                 self.add_cell(cell, ranks)

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -1130,11 +1130,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         >>> CCC.add_cell([9], rank=0)
         >>> CCC.singletons()
         """
-        singletons = []
-        for k in self.skeleton(0):
-            if self.degree(tuple(k)[0], None) == 0:
-                singletons.append(k)
-        return singletons
+        return [k for k in self.skeleton(0) if self.degree(tuple(k)[0], None) == 0]
 
     def remove_singletons(self):
         """Construct new CCC with singleton cells removed.

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -199,7 +199,7 @@ class CombinatorialComplex(ColoredHyperGraph):
             self.nodes[cell].update(attr)
             return
         # we now check if the input is a cell in the CCC
-        elif cell in self.cells:
+        if cell in self.cells:
             hyperedge_ = HyperEdgeView._to_frozen_set(cell)
             rank = self.cells.get_rank(hyperedge_)
             if hyperedge_ in self._complex_set.hyperedge_dict[rank]:
@@ -613,19 +613,19 @@ class CombinatorialComplex(ColoredHyperGraph):
                 for existing_hyperedge in self._node_membership[node]:
                     if existing_hyperedge == hyperedge_:
                         continue
-                    else:
-                        e_rank = self._complex_set.get_rank(existing_hyperedge)
-                        if rank > e_rank and existing_hyperedge.issuperset(hyperedge_):
-                            raise ValueError(
-                                "a violation of the combinatorial complex condition:"
-                                + f"the hyperedge {existing_hyperedge} in the complex has rank {e_rank} is larger than {rank}, the rank of the input hyperedge {hyperedge_} "
-                            )
 
-                        if rank < e_rank and hyperedge_.issuperset(existing_hyperedge):
-                            raise ValueError(
-                                "violation of the combinatorial complex condition : "
-                                + f"the hyperedge {existing_hyperedge} in the complex has rank {e_rank} is smaller than {rank}, the rank of the input hyperedge {hyperedge_} "
-                            )
+                    e_rank = self._complex_set.get_rank(existing_hyperedge)
+                    if rank > e_rank and existing_hyperedge.issuperset(hyperedge_):
+                        raise ValueError(
+                            "a violation of the combinatorial complex condition:"
+                            + f"the hyperedge {existing_hyperedge} in the complex has rank {e_rank} is larger than {rank}, the rank of the input hyperedge {hyperedge_} "
+                        )
+
+                    if rank < e_rank and hyperedge_.issuperset(existing_hyperedge):
+                        raise ValueError(
+                            "violation of the combinatorial complex condition : "
+                            + f"the hyperedge {existing_hyperedge} in the complex has rank {e_rank} is smaller than {rank}, the rank of the input hyperedge {hyperedge_} "
+                        )
 
     def _add_hyperedge(self, hyperedge, rank, **attr):
         """Add hyperedge.
@@ -710,7 +710,7 @@ class CombinatorialComplex(ColoredHyperGraph):
                             "weight"
                         ] = 1
                     return
-                elif e_rank < rank:
+                if e_rank < rank:
                     self._CCC_condition(hyperedge_, rank)
                     self.remove_cell(hyperedge_set)
                     self._add_hyperedge_helper(hyperedge_set, rank, **attr)
@@ -722,16 +722,15 @@ class CombinatorialComplex(ColoredHyperGraph):
                             "weight"
                         ] = 1
                     return
-                else:
-                    self._add_hyperedge_helper(hyperedge_set, rank, **attr)
-                    if (
-                        "weight"
-                        not in self._complex_set.hyperedge_dict[rank][hyperedge_set]
-                    ):
-                        self._complex_set.hyperedge_dict[rank][hyperedge_set][
-                            "weight"
-                        ] = 1
-                    return
+
+                self._add_hyperedge_helper(hyperedge_set, rank, **attr)
+                if (
+                    "weight"
+                    not in self._complex_set.hyperedge_dict[rank][hyperedge_set]
+                ):
+                    self._complex_set.hyperedge_dict[rank][hyperedge_set]["weight"] = 1
+                return
+
             self._CCC_condition(hyperedge_, rank)
             self._add_hyperedge_helper(hyperedge_set, rank, **attr)
             if "weight" not in self._complex_set.hyperedge_dict[rank][hyperedge_set]:
@@ -986,8 +985,7 @@ class CombinatorialComplex(ColoredHyperGraph):
                 shift = len(d)
 
             return d, dirac_mat
-        else:
-            return dirac_mat
+        return dirac_mat
 
     def add_cells_from(self, cells, ranks: Iterable[int] | int | None = None) -> None:
         """Add cells to combinatorial complex.

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -893,7 +893,9 @@ class CombinatorialComplex(ColoredHyperGraph):
             raise ValueError("rank must be lesser than via_rank, must be r<k, got r>k")
         return super().adjacency_matrix(rank, via_rank, s, index)
 
-    def coadjacency_matrix(self, rank, via_rank, s: int = None, index: bool = False):
+    def coadjacency_matrix(
+        self, rank, via_rank, s: int | None = None, index: bool = False
+    ):
         """Compute the coadjacency matrix of self.
 
         The sparse weighted :term:`s-coadjacency matrix`
@@ -1098,9 +1100,10 @@ class CombinatorialComplex(ColoredHyperGraph):
     def clone(self) -> "CombinatorialComplex":
         """Return a copy of the simplex.
 
-        The clone method by default returns an independent shallow copy of the simplex and attributes. That is, if an
-        attribute is a container, that container is shared by the original and the copy. Use Python’s `copy.deepcopy`
-        for new containers.
+        The clone method by default returns an independent shallow copy of the simplex
+        and attributes. That is, if an attribute is a container, that container is
+        shared by the original and the copy. Use Python's `copy.deepcopy` for new
+        containers.
 
         Returns
         -------
@@ -1130,7 +1133,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         >>> CCC.add_cell([9], rank=0)
         >>> CCC.singletons()
         """
-        return [k for k in self.skeleton(0) if self.degree(tuple(k)[0], None) == 0]
+        return [k for k in self.skeleton(0) if self.degree(next(iter(k)), None) == 0]
 
     def remove_singletons(self):
         """Construct new CCC with singleton cells removed.

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -957,7 +957,7 @@ class CombinatorialComplex(ColoredHyperGraph):
 
         index_set = []
         incidence = {}
-        for i in range(0, self.dim + 1):
+        for i in range(self.dim + 1):
             for j in range(i + 1, self.dim + 1):
                 indexj, indexi, Bij = self.incidence_matrix(
                     i, j, weight=weight, index=True
@@ -966,9 +966,9 @@ class CombinatorialComplex(ColoredHyperGraph):
             index_set.append(indexj)
         index_set.append(indexi)
         dirac = []
-        for i in range(0, self.dim + 1):
+        for i in range(self.dim + 1):
             row = []
-            for j in range(0, self.dim + 1):
+            for j in range(self.dim + 1):
                 if (i, j) in incidence:
                     row.append(incidence[(i, j)])
                 elif (j, i) in incidence:

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -295,7 +295,7 @@ class PathComplex(Complex):
 
             # update sub-paths
             for length in range(len(path_), 0, -1):
-                for i in range(0, len(path_) - length + 1):
+                for i in range(len(path_) - length + 1):
                     sub_path = path_[i : i + length]
                     if not self._reserve_sequence_order and str(sub_path[0]) > str(
                         sub_path[-1]
@@ -1031,7 +1031,7 @@ class PathComplex(Complex):
         """
         return {
             tuple(p): self[p][name]
-            for dim in range(0, self.dim + 1)
+            for dim in range(self.dim + 1)
             for p in self.skeleton(dim)
             if name in self[p]
         }

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -379,8 +379,8 @@ class PathComplex(Complex):
     def clone(self) -> "PathComplex":
         """Return a copy of the path complex.
 
-        The clone method by default returns an independent shallow copy of the path complex. Use Python’s
-        `copy.deepcopy` for new containers.
+        The clone method by default returns an independent shallow copy of the path
+        complex. Use Python's `copy.deepcopy` for new containers.
 
         Returns
         -------

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -492,36 +492,36 @@ class PathComplex(Complex):
                     (node,): i for i, node in enumerate(sorted(self.nodes, key=str))
                 }
                 return {}, node_index, abs(boundary.tocoo())
-            else:
-                return abs(boundary.tocoo())
-        else:
-            idx_p_minus_1, idx_p, values = [], [], []
-            path_minus_1_dict = {
-                path: i for i, path in enumerate(self.skeleton(rank - 1))
-            }  # path2idx dict
-            path_dict = {
-                path: i for i, path in enumerate(self.skeleton(rank))
-            }  # path2idx dict
-            for path, idx_path in path_dict.items():
-                for i, _ in enumerate(path):
-                    boundary_path = path[0:i] + path[(i + 1) :]
-                    if not self._reserve_sequence_order and str(boundary_path[0]) > str(
-                        boundary_path[-1]
-                    ):
-                        boundary_path = boundary_path[::-1]
-                    boundary_path = tuple(boundary_path)
-                    if boundary_path in self._allowed_paths:
-                        idx_p_minus_1.append(path_minus_1_dict[boundary_path])
-                        idx_p.append(idx_path)
-                        values.append((-1) ** i)
-            boundary = sp.sparse.coo_matrix(
-                (values, (idx_p_minus_1, idx_p)),
-                dtype=np.float32,
-                shape=(
-                    len(path_minus_1_dict),
-                    len(path_dict),
-                ),
-            )
+            return abs(boundary.tocoo())
+
+        idx_p_minus_1, idx_p, values = [], [], []
+        path_minus_1_dict = {
+            path: i for i, path in enumerate(self.skeleton(rank - 1))
+        }  # path2idx dict
+        path_dict = {
+            path: i for i, path in enumerate(self.skeleton(rank))
+        }  # path2idx dict
+        for path, idx_path in path_dict.items():
+            for i, _ in enumerate(path):
+                boundary_path = path[0:i] + path[(i + 1) :]
+                if not self._reserve_sequence_order and str(boundary_path[0]) > str(
+                    boundary_path[-1]
+                ):
+                    boundary_path = boundary_path[::-1]
+                boundary_path = tuple(boundary_path)
+                if boundary_path in self._allowed_paths:
+                    idx_p_minus_1.append(path_minus_1_dict[boundary_path])
+                    idx_p.append(idx_path)
+                    values.append((-1) ** i)
+        boundary = sp.sparse.coo_matrix(
+            (values, (idx_p_minus_1, idx_p)),
+            dtype=np.float32,
+            shape=(
+                len(path_minus_1_dict),
+                len(path_dict),
+            ),
+        )
+
         if index:
             if signed:
                 return (
@@ -529,17 +529,16 @@ class PathComplex(Complex):
                     path_dict,
                     boundary,
                 )
-            else:
-                return (
-                    path_minus_1_dict,
-                    path_dict,
-                    abs(boundary),
-                )
-        else:
-            if signed:
-                return boundary
-            else:
-                return abs(boundary)
+
+            return (
+                path_minus_1_dict,
+                path_dict,
+                abs(boundary),
+            )
+
+        if signed:
+            return boundary
+        return abs(boundary)
 
     def up_laplacian_matrix(
         self,
@@ -584,8 +583,7 @@ class PathComplex(Complex):
 
         if index:
             return row, L_up.tolil()
-        else:
-            return L_up.tolil()
+        return L_up.tolil()
 
     def down_laplacian_matrix(
         self,
@@ -627,8 +625,7 @@ class PathComplex(Complex):
             L_down = abs(L_down)
         if index:
             return row, L_down.tolil()
-        else:
-            return L_down.tolil()
+        return L_down.tolil()
 
     def hodge_laplacian_matrix(
         self,
@@ -664,9 +661,8 @@ class PathComplex(Complex):
                 L_hodge = abs(L_hodge)
             if index:
                 return row, L_hodge
-            else:
-                return L_hodge
-        elif rank < self.dim:
+            return L_hodge
+        if rank < self.dim:
             row, column, B_next = self.incidence_matrix(
                 rank + 1, weight=weight, index=True
             )
@@ -676,21 +672,19 @@ class PathComplex(Complex):
                 L_hodge = abs(L_hodge)
             if index:
                 return column, L_hodge
-            else:
-                return L_hodge
-        elif rank == self.dim:
+            return L_hodge
+        if rank == self.dim:
             row, column, B = self.incidence_matrix(rank, weight=weight, index=True)
             L_hodge = B.transpose() @ B
             if not signed:
                 L_hodge = abs(L_hodge)
             if index:
                 return column, L_hodge
-            else:
-                return L_hodge
-        else:
-            raise ValueError(
-                f"Rank should be larger than 0 and <= {self.dim} (maximal dimension simplices), got {rank}"
-            )
+            return L_hodge
+
+        raise ValueError(
+            f"Rank should be larger than 0 and <= {self.dim} (maximal dimension simplices), got {rank}"
+        )
 
     def adjacency_matrix(
         self,
@@ -815,9 +809,8 @@ class PathComplex(Complex):
         new_path_set = []
         if len(path_set) == 0:
             raise ValueError("Input path_set cannot be empty.")
-        else:
-            for path in path_set:
-                new_path_set.append(tuple(path))
+        for path in path_set:
+            new_path_set.append(tuple(path))
         new_path_set = set(new_path_set)
         new_paths = []
         for path in self.paths:
@@ -1141,8 +1134,7 @@ class PathComplex(Complex):
         if path not in self._path_set.faces_dict[dim]:  # Not in faces_dict
             self._path_set.faces_dict[dim][path] = {}
             return path
-        else:
-            return None
+        return None
 
     def _update_attributes(self, path, **attr):
         """Update the attributes of path.
@@ -1198,8 +1190,7 @@ class PathComplex(Complex):
         """
         if item in self:
             return self._path_set[item]
-        else:
-            raise KeyError("The elementary p-path is not in the path complex")
+        raise KeyError("The elementary p-path is not in the path complex")
 
     def __iter__(self) -> Iterator:
         """Iterate over all faces of the path complex.

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -778,10 +778,9 @@ class PathComplex(Complex):
         if len(node_set) == 0:
             raise ValueError("Input node_set cannot be empty.")
         node_set = set(node_set)
-        new_paths = []
-        for path in self.paths:
-            if all(node in node_set for node in path):
-                new_paths.append(path)
+        new_paths = [
+            path for path in self.paths if all(node in node_set for node in path)
+        ]
         return PathComplex(new_paths)
 
     def restrict_to_paths(self, path_set: Iterable[Sequence[Hashable]]):
@@ -806,16 +805,11 @@ class PathComplex(Complex):
         >>> PC.paths
         PathView([(1,), (2,), (3,), (1, 2), (2, 3), (1, 2, 3)])
         """
-        new_path_set = []
         if len(path_set) == 0:
             raise ValueError("Input path_set cannot be empty.")
-        for path in path_set:
-            new_path_set.append(tuple(path))
+        new_path_set = [tuple(path) for path in path_set]
         new_path_set = set(new_path_set)
-        new_paths = []
-        for path in self.paths:
-            if path in new_path_set:
-                new_paths.append(path)
+        new_paths = [path for path in self.paths if path in new_path_set]
         return PathComplex(new_paths)
 
     def get_node_attributes(self, name: str) -> dict[tuple[Hashable], Any]:

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -126,7 +126,7 @@ class CellView(AtomView[Cell]):
             ]
 
         # If a tuple or list is passed in, assume it represents a cell
-        elif isinstance(cell, tuple | list):
+        if isinstance(cell, tuple | list):
             cell = tuple(cell)
             if cell in self._cells:
                 if len(self._cells[cell]) == 1:
@@ -171,7 +171,7 @@ class CellView(AtomView[Cell]):
             return [self._cells[cell.elements][c] for c in self._cells[cell.elements]]
 
         # If a tuple or list is passed in, assume it represents a cell
-        elif isinstance(cell, tuple | list):
+        if isinstance(cell, tuple | list):
             cell = tuple(cell)
             if cell in self._cells:
                 if len(self._cells[cell]) == 1:
@@ -330,10 +330,10 @@ class ColoredHyperEdgeView(AtomView):
         for r in self.hyperedge_dict:
             if r == 0:
                 continue
-            else:
-                for he in self.hyperedge_dict[r]:
-                    for k in self.hyperedge_dict[r][he]:
-                        lst.append((he, k))
+
+            for he in self.hyperedge_dict[r]:
+                for k in self.hyperedge_dict[r][he]:
+                    lst.append((he, k))
         return iter(lst)
 
     def __contains__(self, atom: Any) -> bool:
@@ -383,21 +383,20 @@ class ColoredHyperEdgeView(AtomView):
         ):
             if len(hyperedge_elements) == 0:
                 return False
-            else:
-                for i in all_ranks:
-                    if frozenset(hyperedge_elements) in self.hyperedge_dict[i]:
-                        return (
-                            key in self.hyperedge_dict[i][frozenset(hyperedge_elements)]
-                        )
-                return False
-        elif isinstance(hyperedge_elements, HyperEdge):
+
+            for i in all_ranks:
+                if frozenset(hyperedge_elements) in self.hyperedge_dict[i]:
+                    return key in self.hyperedge_dict[i][frozenset(hyperedge_elements)]
+            return False
+        if isinstance(hyperedge_elements, HyperEdge):
             if len(hyperedge_elements) == 0:
                 return False
-            else:
-                for i in all_ranks:
-                    if frozenset(hyperedge_elements.elements) in self.hyperedge_dict[i]:
-                        return True
-                return False
+
+            for i in all_ranks:
+                if frozenset(hyperedge_elements.elements) in self.hyperedge_dict[i]:
+                    return True
+            return False
+        return None
 
     def __repr__(self) -> str:
         """Return string representation of hyperedges.
@@ -436,6 +435,7 @@ class ColoredHyperEdgeView(AtomView):
         """
         if rank not in self.hyperedge_dict:
             return []
+
         if store_hyperedge_key:
             return sorted(
                 [
@@ -444,14 +444,14 @@ class ColoredHyperEdgeView(AtomView):
                     for k in self.hyperedge_dict[rank][he]
                 ]
             )
-        else:
-            return sorted(
-                [
-                    he
-                    for he in self.hyperedge_dict[rank]
-                    for k in self.hyperedge_dict[rank][he]
-                ]
-            )
+
+        return sorted(
+            [
+                he
+                for he in self.hyperedge_dict[rank]
+                for k in self.hyperedge_dict[rank][he]
+            ]
+        )
 
     def get_rank(self, edge):
         """Get the rank of a given hyperedge.
@@ -469,29 +469,28 @@ class ColoredHyperEdgeView(AtomView):
         if isinstance(edge, HyperEdge):
             if len(edge) == 0:
                 return 0
-            else:
-                for i in list(self.allranks):
-                    if frozenset(edge.elements) in self.hyperedge_dict[i]:
-                        return i
-                raise KeyError(f"hyperedge {edge.elements} is not in the complex")
-        elif isinstance(edge, str):
+
+            for i in list(self.allranks):
+                if frozenset(edge.elements) in self.hyperedge_dict[i]:
+                    return i
+            raise KeyError(f"hyperedge {edge.elements} is not in the complex")
+        if isinstance(edge, str):
             if frozenset({edge}) in self.hyperedge_dict[0]:
                 return 0
-            else:
-                raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
-        elif isinstance(edge, Iterable):
+            raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+        if isinstance(edge, Iterable):
             if len(edge) == 0:
                 return 0
-            else:
-                for i in list(self.allranks):
-                    if frozenset(edge) in self.hyperedge_dict[i]:
-                        return i
-                raise KeyError(f"hyperedge {edge} is not in the complex")
-        elif isinstance(edge, Hashable) and not isinstance(edge, Iterable):
+
+            for i in list(self.allranks):
+                if frozenset(edge) in self.hyperedge_dict[i]:
+                    return i
+            raise KeyError(f"hyperedge {edge} is not in the complex")
+        if isinstance(edge, Hashable) and not isinstance(edge, Iterable):
             if frozenset({edge}) in self.hyperedge_dict[0]:
                 return 0
-            else:
-                raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+            raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+        return None
 
     @property
     def allranks(self) -> list[int]:
@@ -619,18 +618,18 @@ class HyperEdgeView(AtomView):
         if isinstance(atom, HyperEdge):
             if len(atom) == 0:
                 return False
-            else:
-                for i in all_ranks:
-                    if frozenset(atom.elements) in self.hyperedge_dict[i]:
-                        return True
-                return False
-        elif isinstance(atom, Iterable):
+
+            for i in all_ranks:
+                if frozenset(atom.elements) in self.hyperedge_dict[i]:
+                    return True
+            return False
+        if isinstance(atom, Iterable):
             if len(atom) == 0:
                 return False
-            else:
-                return any(frozenset(atom) in self.hyperedge_dict[i] for i in all_ranks)
-        elif isinstance(atom, Hashable):
+            return any(frozenset(atom) in self.hyperedge_dict[i] for i in all_ranks)
+        if isinstance(atom, Hashable):
             return frozenset({atom}) in self.hyperedge_dict[0]
+        return None
 
     def __repr__(self) -> str:
         """Return string representation of hyperedges.
@@ -684,41 +683,34 @@ class HyperEdgeView(AtomView):
         if level == "equal":
             if rank in self.allranks:
                 return sorted(self.hyperedge_dict[rank].keys())
-            else:
-                return []
-
-        elif level in {"upper", "up"}:
+            return []
+        if level in {"upper", "up"}:
             elements = []
             for rank_i in self.allranks:
                 if rank_i > rank:
                     elements = elements + list(self.hyperedge_dict[rank_i].keys())
             return sorted(elements)
-
-        elif level in {"lower", "down"}:
+        if level in {"lower", "down"}:
             elements = []
             for rank_i in self.allranks:
                 if rank_i < rank:
                     elements = elements + list(self.hyperedge_dict[rank_i].keys())
             return sorted(elements)
-
-        elif level in {"uppereq", "upeq"}:
+        if level in {"uppereq", "upeq"}:
             elements = []
             for rank_i in self.allranks:
                 if rank_i >= rank:
                     elements = elements + list(self.hyperedge_dict[rank_i].keys())
             return sorted(elements)
-
-        elif level in {"lowereq", "downeq"}:
+        if level in {"lowereq", "downeq"}:
             elements = []
             for rank_i in self.allranks:
                 if rank_i <= rank:
                     elements = elements + list(self.hyperedge_dict[rank_i].keys())
             return sorted(elements)
-
-        else:
-            raise ValueError(
-                "level must be 'equal', 'uppereq', 'lowereq', 'upeq', 'downeq', 'uppereq', 'lower', 'up', or 'down'  "
-            )
+        raise ValueError(
+            "level must be 'equal', 'uppereq', 'lowereq', 'upeq', 'downeq', 'uppereq', 'lower', 'up', or 'down'"
+        )
 
     def get_rank(self, edge):
         """Get the rank of a hyperedge.
@@ -736,29 +728,28 @@ class HyperEdgeView(AtomView):
         if isinstance(edge, HyperEdge):
             if len(edge) == 0:
                 return 0
-            else:
-                for i in list(self.allranks):
-                    if frozenset(edge.elements) in self.hyperedge_dict[i]:
-                        return i
-                raise KeyError(f"hyperedge {edge.elements} is not in the complex")
-        elif isinstance(edge, str):
+
+            for i in list(self.allranks):
+                if frozenset(edge.elements) in self.hyperedge_dict[i]:
+                    return i
+            raise KeyError(f"hyperedge {edge.elements} is not in the complex")
+        if isinstance(edge, str):
             if frozenset({edge}) in self.hyperedge_dict[0]:
                 return 0
-            else:
-                raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
-        elif isinstance(edge, Iterable):
+            raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+        if isinstance(edge, Iterable):
             if len(edge) == 0:
                 return 0
-            else:
-                for i in list(self.allranks):
-                    if frozenset(edge) in self.hyperedge_dict[i]:
-                        return i
-                raise KeyError(f"hyperedge {edge} is not in the complex")
-        elif isinstance(edge, Hashable) and not isinstance(edge, Iterable):
+
+            for i in list(self.allranks):
+                if frozenset(edge) in self.hyperedge_dict[i]:
+                    return i
+            raise KeyError(f"hyperedge {edge} is not in the complex")
+        if isinstance(edge, Hashable) and not isinstance(edge, Iterable):
             if frozenset({edge}) in self.hyperedge_dict[0]:
                 return 0
-            else:
-                raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+            raise KeyError(f"hyperedge {frozenset({edge})} is not in the complex")
+        return None
 
     @property
     def allranks(self):
@@ -861,15 +852,15 @@ class SimplexView(AtomView[Simplex]):
         if isinstance(simplex, Simplex):
             if simplex.elements in self.faces_dict[len(simplex) - 1]:
                 return self.faces_dict[len(simplex) - 1][simplex.elements]
-        elif isinstance(simplex, Iterable):
+            return None
+        if isinstance(simplex, Iterable):
             simplex = frozenset(simplex)
             if simplex in self.faces_dict[len(simplex) - 1]:
                 return self.faces_dict[len(simplex) - 1][simplex]
-            else:
-                raise KeyError(f"input {simplex} is not in the simplex dictionary")
-
-        elif isinstance(simplex, Hashable) and frozenset({simplex}) in self:
+            raise KeyError(f"input {simplex} is not in the simplex dictionary")
+        if isinstance(simplex, Hashable) and frozenset({simplex}) in self:
             return self.faces_dict[0][frozenset({simplex})]
+        return None
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -943,7 +934,7 @@ class SimplexView(AtomView[Simplex]):
             if not 0 < len(atom) <= self.max_dim + 1:
                 return False
             return atom in self.faces_dict[len(atom) - 1]
-        elif isinstance(atom, Hashable):
+        if isinstance(atom, Hashable):
             return frozenset({atom}) in self.faces_dict[0]
         return False
 
@@ -1052,14 +1043,12 @@ class NodeView:
             if cell in self.nodes:
                 if self.colored_nodes:
                     return self.nodes[cell][0]
-                else:
-                    return self.nodes[cell]
+                return self.nodes[cell]
         elif isinstance(cell, Hashable):
             if cell in self:
                 if self.colored_nodes:
                     return self.nodes[frozenset({cell})][0]
-                else:
-                    return self.nodes[frozenset({cell})]
+                return self.nodes[frozenset({cell})]
 
         raise KeyError(f"input {cell} is not in the node set of the complex")
 
@@ -1088,15 +1077,13 @@ class NodeView:
         """
         if isinstance(e, Hashable) and not isinstance(e, self.cell_type):
             return frozenset({e}) in self.nodes
-
-        elif isinstance(e, self.cell_type):
+        if isinstance(e, self.cell_type):
             return e.elements in self.nodes
-
-        elif isinstance(e, Iterable):
+        if isinstance(e, Iterable):
             if len(e) == 1:
                 return frozenset(e) in self.nodes
-        else:
-            return False
+            return None
+        return False
 
 
 class PathView(SimplexView):
@@ -1156,12 +1143,12 @@ class PathView(SimplexView):
             if not 0 < len(atom) <= self.max_dim + 1:
                 return False
             return atom in self.faces_dict[len(atom) - 1]
-        elif isinstance(atom, Path):
+        if isinstance(atom, Path):
             atom = atom.elements
             if not 0 < len(atom) <= self.max_dim + 1:
                 return False
             return atom in self.faces_dict[len(atom) - 1]
-        elif isinstance(atom, Hashable):
+        if isinstance(atom, Hashable):
             return (atom,) in self.faces_dict[0]
         return False
 

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -331,9 +331,11 @@ class ColoredHyperEdgeView(AtomView):
             if r == 0:
                 continue
 
-            for he in self.hyperedge_dict[r]:
-                for k in self.hyperedge_dict[r][he]:
-                    lst.append((he, k))
+            lst.extend(
+                (he, k)
+                for he in self.hyperedge_dict[r]
+                for k in self.hyperedge_dict[r][he]
+            )
         return iter(lst)
 
     def __contains__(self, atom: Any) -> bool:

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -220,9 +220,10 @@ class Simplex(Atom):
     def clone(self) -> "Simplex":
         """Return a copy of the simplex.
 
-        The clone method by default returns an independent shallow copy of the simplex and attributes. That is, if an
-        attribute is a container, that container is shared by the original and the copy. Use Python’s `copy.deepcopy`
-        for new containers.
+        The clone method by default returns an independent shallow copy of the simplex
+        and attributes. That is, if an attribute is a container, that container is
+        shared by the original and the copy. Use Python's `copy.deepcopy` for new
+        containers.
 
         Returns
         -------

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -74,6 +74,7 @@ class Simplex(Atom):
             warnings.warn(
                 "The `construct_tree` argument is deprecated.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         for i in elements:
@@ -128,7 +129,9 @@ class Simplex(Atom):
             The set of faces of the simplex.
         """
         warnings.warn(
-            "`Simplex.construct_simplex_tree` is deprecated.", DeprecationWarning
+            "`Simplex.construct_simplex_tree` is deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
         faceset = set()
@@ -156,6 +159,7 @@ class Simplex(Atom):
         warnings.warn(
             "`Simplex.boundary` is deprecated, use `SimplicialComplex.get_boundaries()` on the simplicial complex that contains this simplex instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         return frozenset(
@@ -188,6 +192,7 @@ class Simplex(Atom):
         warnings.warn(
             "`Simplex.faces` is deprecated, use `SimplicialComplex.get_boundaries()` on the simplicial complex that contains this simplex instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         return Simplex.construct_simplex_tree(self.elements)

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -1057,14 +1057,14 @@ class SimplicialComplex(Complex):
 
         index_set = []
         incidence = {}
-        for i in range(0, self.dim + 1):
+        for i in range(self.dim + 1):
             _, indexi, Bi = self.incidence_matrix(i, weight=weight, index=True)
             index_set.append(indexi)
             incidence[(i, i + 1)] = Bi
         dirac = []
-        for i in range(0, self.dim + 1):
+        for i in range(self.dim + 1):
             row = []
-            for j in range(0, self.dim + 1):
+            for j in range(self.dim + 1):
                 if (i, j) in incidence:
                     row.append(incidence[(i + 1, j + 1)])
                 elif (j, i) in incidence:
@@ -1439,9 +1439,7 @@ class SimplicialComplex(Complex):
         first_ind = np.min(mesh.trilist)
 
         if first_ind == 0:
-            SC.set_simplex_attributes(
-                dict(enumerate(vertices)), name="position"
-            )
+            SC.set_simplex_attributes(dict(enumerate(vertices)), name="position")
         else:  # first index starts at 1.
             SC.set_simplex_attributes(
                 dict(enumerate(vertices, first_ind)),

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -801,7 +801,7 @@ class SimplicialComplex(Complex):
         can be reduced to G computations.
         """
         rows, cols = np.where(np.sign(np.abs(matrix)) > 0)
-        edges = zip(rows.tolist(), cols.tolist())
+        edges = zip(rows.tolist(), cols.tolist(), strict=True)
         return edges
 
     def incidence_matrix(
@@ -1440,11 +1440,11 @@ class SimplicialComplex(Complex):
 
         if first_ind == 0:
             SC.set_simplex_attributes(
-                dict(zip(range(len(vertices)), vertices)), name="position"
+                dict(enumerate(vertices)), name="position"
             )
         else:  # first index starts at 1.
             SC.set_simplex_attributes(
-                dict(zip(range(first_ind, len(vertices) + first_ind), vertices)),
+                dict(enumerate(vertices, first_ind)),
                 name="position",
             )
 
@@ -1533,13 +1533,12 @@ class SimplicialComplex(Complex):
 
         if first_ind == 0:
             SC.set_simplex_attributes(
-                dict(zip(range(len(mesh.vertices)), mesh.vertices)), name="position"
+                dict(enumerate(mesh.vertices)),
+                name="position",
             )
         else:  # first index starts at 1.
             SC.set_simplex_attributes(
-                dict(
-                    zip(range(first_ind, len(mesh.vertices) + first_ind), mesh.vertices)
-                ),
+                dict(enumerate(mesh.vertices, first_ind)),
                 name="position",
             )
 

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -323,8 +323,7 @@ class SimplicialComplex(Complex):
         """
         if simplex in self:
             return self._simplex_set[simplex]
-        else:
-            raise KeyError("simplex is not in the simplicial complex")
+        raise KeyError("simplex is not in the simplicial complex")
 
     def __iter__(self) -> Iterator:
         """Iterate over all simplices (faces) of the simplicial complex.
@@ -801,8 +800,7 @@ class SimplicialComplex(Complex):
         can be reduced to G computations.
         """
         rows, cols = np.where(np.sign(np.abs(matrix)) > 0)
-        edges = zip(rows.tolist(), cols.tolist(), strict=True)
-        return edges
+        return zip(rows.tolist(), cols.tolist(), strict=True)
 
     def incidence_matrix(
         self, rank, signed: bool = True, weight: str | None = None, index: bool = False
@@ -863,8 +861,7 @@ class SimplicialComplex(Complex):
                     simplex: i for i, simplex in enumerate(self.skeleton(0))
                 }
                 return {}, simplex_dict_d, boundary.tocsr()
-            else:
-                return boundary.tocsr()
+            return boundary.tocsr()
 
         idx_simplices, idx_faces, values = [], [], []
 
@@ -887,6 +884,7 @@ class SimplicialComplex(Complex):
                 len(simplex_dict_d),
             ),
         )
+
         if index:
             if signed:
                 return (
@@ -894,17 +892,15 @@ class SimplicialComplex(Complex):
                     simplex_dict_d,
                     boundary,
                 )
-            else:
-                return (
-                    simplex_dict_d_minus_1,
-                    simplex_dict_d,
-                    abs(boundary),
-                )
-        else:
-            if signed:
-                return boundary
-            else:
-                return abs(boundary)
+            return (
+                simplex_dict_d_minus_1,
+                simplex_dict_d,
+                abs(boundary),
+            )
+
+        if signed:
+            return boundary
+        return abs(boundary)
 
     def coincidence_matrix(
         self, rank, signed: bool = True, weight=None, index: bool = False
@@ -985,9 +981,8 @@ class SimplicialComplex(Complex):
                 L_hodge = abs(L_hodge)
             if index:
                 return row, L_hodge
-            else:
-                return L_hodge
-        elif rank < self.dim:
+            return L_hodge
+        if rank < self.dim:
             row, column, B_next = self.incidence_matrix(
                 rank + 1, weight=weight, index=True
             )
@@ -997,25 +992,19 @@ class SimplicialComplex(Complex):
                 L_hodge = abs(L_hodge)
             if index:
                 return column, L_hodge
-            else:
-                return L_hodge
-        elif rank == self.dim:
+            return L_hodge
+        if rank == self.dim:
             row, column, B = self.incidence_matrix(rank, weight=weight, index=True)
             L_hodge = B.transpose() @ B
             if not signed:
                 L_hodge = abs(L_hodge)
             if index:
                 return column, L_hodge
-            else:
-                return L_hodge
-        else:
-            raise ValueError(
-                f"Rank should be larger than 0 and <= {self.dim} (maximal dimension simplices), got {rank}"
-            )
-        if not signed:
-            L_hodge = abs(L_hodge)
-        else:
-            return abs(L_hodge)
+            return L_hodge
+
+        raise ValueError(
+            f"Rank should be larger than 0 and <= {self.dim} (maximal dimension simplices), got {rank}"
+        )
 
     def dirac_operator_matrix(
         self,

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -1715,7 +1715,7 @@ class SimplicialComplex(Complex):
             edge = list(edge)
             G.add_edge(edge[0], edge[1])
         for node in self.skeleton(0):
-            G.add_node(list(node)[0])
+            G.add_node(next(iter(node)))
         return nx.is_connected(G)
 
     @classmethod
@@ -1814,8 +1814,8 @@ class SimplicialComplex(Complex):
     def clone(self) -> "SimplicialComplex":
         """Return a copy of the simplicial complex.
 
-        The clone method by default returns an independent shallow copy of the simplicial complex. Use Python’s
-        `copy.deepcopy` for new containers.
+        The clone method by default returns an independent shallow copy of the
+        simplicial complex. Use Python's `copy.deepcopy` for new containers.
 
         Returns
         -------

--- a/toponetx/datasets/graph.py
+++ b/toponetx/datasets/graph.py
@@ -95,16 +95,19 @@ def karate_club(
         )
 
         sc.set_simplex_attributes(
-            dict(zip(sc.skeleton(0), np.array(nodes_feat))), name="node_feat"
+            dict(zip(sc.skeleton(0), np.array(nodes_feat), strict=True)),
+            name="node_feat",
         )
         sc.set_simplex_attributes(
-            dict(zip(sc.skeleton(1), np.array(edges_feat))), name="edge_feat"
+            dict(zip(sc.skeleton(1), np.array(edges_feat), strict=True)),
+            name="edge_feat",
         )
         sc.set_simplex_attributes(
-            dict(zip(sc.skeleton(2), np.array(faces_feat))), name="face_feat"
+            dict(zip(sc.skeleton(2), np.array(faces_feat), strict=True)),
+            name="face_feat",
         )
         sc.set_simplex_attributes(
-            dict(zip(sc.skeleton(3), np.array(tetrahedron_feat))),
+            dict(zip(sc.skeleton(3), np.array(tetrahedron_feat), strict=True)),
             name="tetrahedron_feat",
         )
 
@@ -127,13 +130,19 @@ def karate_club(
         )
 
         cx.set_cell_attributes(
-            dict(zip(cx.skeleton(0), np.array(nodes_feat))), name="node_feat", rank=0
+            dict(zip(cx.skeleton(0), np.array(nodes_feat), strict=True)),
+            name="node_feat",
+            rank=0,
         )
         cx.set_cell_attributes(
-            dict(zip(cx.skeleton(1), np.array(edges_feat))), name="edge_feat", rank=1
+            dict(zip(cx.skeleton(1), np.array(edges_feat), strict=True)),
+            name="edge_feat",
+            rank=1,
         )
         cx.set_cell_attributes(
-            dict(zip(cx.skeleton(2), np.array(cells_feat))), name="cell_feat", rank=2
+            dict(zip(cx.skeleton(2), np.array(cells_feat), strict=True)),
+            name="cell_feat",
+            rank=2,
         )
         return cx
 

--- a/toponetx/generators/random_simplicial_complexes.py
+++ b/toponetx/generators/random_simplicial_complexes.py
@@ -43,7 +43,7 @@ def linial_meshulam_complex(n: int, p: float, seed=None) -> SimplicialComplex:
     References
     ----------
     .. [1] Nathan Linial and Roy Meshulam, "Homological Connectivity Of Random
-           2-Complexes," Combinatorica 26, no. 4 (August 2006): 475–87,
+           2-Complexes," Combinatorica 26, no. 4 (August 2006): 475-87,
            https://doi.org/10.1007/s00493-006-0027-9.
     """
     return multiparameter_linial_meshulam_complex(n, [1.0, p], seed)
@@ -72,7 +72,7 @@ def random_clique_complex(n: int, p: float, seed=None) -> SimplicialComplex:
     References
     ----------
     .. [1] Matthew Kahle, "Topology of Random Clique Complexes,"
-           Discrete Mathematics 309, no. 6 (April 2009): 1658–71,
+           Discrete Mathematics 309, no. 6 (April 2009): 1658-71,
            https://doi.org/10.1016/j.disc.2008.02.037.
     """
     graph = nx.gnp_random_graph(n, p, seed)

--- a/toponetx/readwrite/atomlist.py
+++ b/toponetx/readwrite/atomlist.py
@@ -161,7 +161,7 @@ def write_atomlist(
     domain : CellComplex or SimplicialComplex
         The complex to be converted to an atom list.
     path : file or str
-        File or filename to write. If a file is provided, it must be opened in ‘wb’
+        File or filename to write. If a file is provided, it must be opened in `wb`
         mode. Filenames ending in .gz or .bz2 will be compressed.
     encoding : str, default="utf-8"
        Specify which encoding to use when writing file.
@@ -202,7 +202,7 @@ def load_from_atomlist(
     Parameters
     ----------
     path : file or str
-        File or filename to read. If a file is provided, it must be opened in ‘rb’
+        File or filename to read. If a file is provided, it must be opened in `rb`
         mode. Filenames ending in .gz or .bz2 will be uncompressed.
     complex_type : {"cell", "simplicial"}
         The type of complex that should be constructed based on the atom list.

--- a/toponetx/readwrite/serialization.py
+++ b/toponetx/readwrite/serialization.py
@@ -32,5 +32,4 @@ def load_from_pickle(filepath):
         Object.
     """
     with open(filepath, "rb") as f:
-        temp = pickle.load(f)
-    return temp
+        return pickle.load(f)

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -153,8 +153,7 @@ def weighted_graph_to_vietoris_rips_complex(
 
     def is_in_vr_complex(clique):  # numpydoc ignore=GL08
         edges = combinations(clique, 2)
-        edge_weights_lower_than_r = all(G[u][v]["weight"] <= r for u, v in edges)
-        return edge_weights_lower_than_r
+        return all(G[u][v]["weight"] <= r for u, v in edges)
 
     all_cliques = nx.enumerate_all_cliques(G)
     possible_cliques = (

--- a/toponetx/utils/normalization.py
+++ b/toponetx/utils/normalization.py
@@ -106,9 +106,7 @@ def compute_kipf_adjacency_normalized_matrix(
     r_inv_sqrt = np.power(rowsum, -0.5).flatten()
     r_inv_sqrt[np.isinf(r_inv_sqrt)] = 0.0
     r_mat_inv_sqrt = diags(r_inv_sqrt)
-    A_opt_normalized = A_opt.dot(r_mat_inv_sqrt).transpose().dot(r_mat_inv_sqrt)
-
-    return A_opt_normalized
+    return A_opt.dot(r_mat_inv_sqrt).transpose().dot(r_mat_inv_sqrt)
 
 
 def compute_xu_asymmetric_normalized_matrix(
@@ -140,15 +138,13 @@ def compute_xu_asymmetric_normalized_matrix(
         r_inv = np.power(rowsum, -1).flatten()
         r_inv[np.isinf(r_inv)] = 0.0
         r_mat_inv = diags(r_inv)
-        normalized_matrix = r_mat_inv.dot(B)
-        return normalized_matrix
-    else:
-        Di = np.sum(np.abs(B), axis=1)
-        Di2 = np.diag(np.power(Di, -1))
-        Di2[np.isinf(Di2)] = 0.0
-        B = np.array(B)
-        normalized_matrix = Di2.dot(B)
-        return normalized_matrix
+        return r_mat_inv.dot(B)
+
+    Di = np.sum(np.abs(B), axis=1)
+    Di2 = np.diag(np.power(Di, -1))
+    Di2[np.isinf(Di2)] = 0.0
+    B = np.array(B)
+    return Di2.dot(B)
 
 
 def compute_bunch_normalized_matrices(
@@ -290,7 +286,7 @@ def _compute_B2T_normalized_matrix(
     if isinstance(B2, np.ndarray):
         D5_pinv = pinv(D5)
         return B2.T @ D5_pinv
-    elif isinstance(B2, csr_matrix):
+    if isinstance(B2, csr_matrix):
         D5_pinv = csr_matrix(pinv(D5.toarray()))
         return B2.T @ D5_pinv
     raise TypeError("input type must be either np.ndarray or csr_matrix")
@@ -313,12 +309,10 @@ def _compute_D1(B1: np.ndarray | csr_matrix, D2: diags) -> diags:
     """
     if isinstance(B1, csr_matrix):
         rowsum = np.array((np.abs(B1) @ D2).sum(axis=1)).flatten()
-        D1 = 2 * diags(rowsum)
-        return D1
-    elif isinstance(B1, np.ndarray):
+        return 2 * diags(rowsum)
+    if isinstance(B1, np.ndarray):
         rowsum = (np.abs(B1) @ D2).sum(axis=1)
-        D1 = 2 * np.diag(rowsum)
-        return D1
+        return 2 * np.diag(rowsum)
     raise TypeError("Input type must be either np.ndarray or csr_matrix.")
 
 
@@ -337,12 +331,10 @@ def _compute_D2(B2: np.ndarray | csr_matrix) -> diags:
     """
     if isinstance(B2, csr_matrix):
         rowsum = np.array(np.abs(B2).sum(axis=1)).flatten()
-        D2 = diags(np.maximum(rowsum, 1))
-        return D2
-    elif isinstance(B2, np.ndarray):
+        return diags(np.maximum(rowsum, 1))
+    if isinstance(B2, np.ndarray):
         rowsum = np.abs(B2).sum(axis=1)
-        D2 = np.diag(np.maximum(rowsum, 1))
-        return D2
+        return np.diag(np.maximum(rowsum, 1))
     raise TypeError("Input type must be either np.ndarray or csr_matrix.")
 
 
@@ -360,11 +352,9 @@ def _compute_D3(B2: np.ndarray | csr_matrix) -> diags:
         Degree matrix D3.
     """
     if isinstance(B2, csr_matrix):
-        D3 = diags(np.ones(B2.shape[1]) / 3)
-        return D3
-    elif isinstance(B2, np.ndarray):
-        D3 = np.diag(np.ones(B2.shape[1]) / 3)
-        return D3
+        return diags(np.ones(B2.shape[1]) / 3)
+    if isinstance(B2, np.ndarray):
+        return np.diag(np.ones(B2.shape[1]) / 3)
     raise TypeError("Input type must be either np.ndarray or csr_matrix.")
 
 
@@ -383,10 +373,8 @@ def _compute_D5(B2: np.ndarray | csr_matrix) -> diags:
     """
     if isinstance(B2, csr_matrix):
         rowsum = np.array(np.abs(B2).sum(axis=1)).flatten()
-        D5 = diags(rowsum)
-        return D5
-    elif isinstance(B2, np.ndarray):
+        return diags(rowsum)
+    if isinstance(B2, np.ndarray):
         rowsum = np.abs(B2).sum(axis=1)
-        D5 = np.diag(rowsum)
-        return D5
+        return np.diag(rowsum)
     raise TypeError("Input type must be either np.ndarray or csr_matrix.")

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -68,12 +68,13 @@ def sparse_array_to_neighborhood_list(
 
     if src_dict is None and dst_dict is None:
         return zip(dst_idx, src_idx, strict=True)
-    elif src_dict is not None and dst_dict is not None:
+
+    if src_dict is not None and dst_dict is not None:
         src_list = [src_dict[i] for i in src_idx]
         dest_list = [dst_dict[i] for i in dst_idx]
         return zip(dest_list, src_list, strict=True)
-    else:
-        raise ValueError("src_dict and dst_dict must be either None or both not None")
+
+    raise ValueError("src_dict and dst_dict must be either None or both not None")
 
 
 def neighborhood_list_to_neighborhood_dict(
@@ -104,12 +105,13 @@ def neighborhood_list_to_neighborhood_dict(
         for src_idx, dst_idx in n_list:
             neighborhood_dict[src_idx].append(dst_idx)
         return neighborhood_dict
-    elif src_dict is not None and dst_dict is not None:
+
+    if src_dict is not None and dst_dict is not None:
         for src_idx, dst_idx in n_list:
             neighborhood_dict[src_dict[src_idx]].append(dst_dict[dst_idx])
         return neighborhood_dict
-    else:
-        raise ValueError("src_dict and dst_dict must be either None or both not None")
+
+    raise ValueError("src_dict and dst_dict must be either None or both not None")
 
 
 def sparse_array_to_neighborhood_dict(
@@ -235,10 +237,8 @@ def compute_set_incidence(children, uidset, sparse: bool = True, index: bool = F
                         MP[ndict[r_hyperedge_dict[n]], edict[k_hyperedge_dict[e]]] = 1
         if index:
             return ndict, edict, MP
-        else:
-            return MP
-    else:
-        if index:
-            return {}, {}, np.zeros(1)
-        else:
-            return np.zeros(1)
+        return MP
+
+    if index:
+        return {}, {}, np.zeros(1)
+    return np.zeros(1)

--- a/toponetx/utils/structure.py
+++ b/toponetx/utils/structure.py
@@ -67,11 +67,11 @@ def sparse_array_to_neighborhood_list(
     src_idx, dst_idx = sparse_array.nonzero()
 
     if src_dict is None and dst_dict is None:
-        return zip(dst_idx, src_idx)
+        return zip(dst_idx, src_idx, strict=True)
     elif src_dict is not None and dst_dict is not None:
         src_list = [src_dict[i] for i in src_idx]
         dest_list = [dst_dict[i] for i in dst_idx]
-        return zip(dest_list, src_list)
+        return zip(dest_list, src_list, strict=True)
     else:
         raise ValueError("src_dict and dst_dict must be either None or both not None")
 
@@ -198,8 +198,8 @@ def compute_set_incidence(children, uidset, sparse: bool = True, index: bool = F
     MP : scipy.sparse.csr.csr_matrix
         Set-based incidence matrix.
     """
-    ndict = dict(zip(children, range(len(children))))
-    edict = dict(zip(uidset, range(len(uidset))))
+    ndict = dict(zip(children, range(len(children)), strict=True))
+    edict = dict(zip(uidset, range(len(uidset)), strict=True))
 
     ndict = OrderedDict(sorted(ndict.items(), key=itemgetter(1)))
     edict = OrderedDict(sorted(edict.items(), key=itemgetter(1)))


### PR DESCRIPTION
This pull request activates some additional linting rules and fixes occurring errors as a result of them.

Some noticeable new rules:
- `zip()`: Use the optional `strict` parameter to error when the provided iterables are not of same length. This should catch some erroneous user inputs.
- Remove unnecessary `elif` and `else` branches if the previous branch is guaranteed to return. This reduces indentation and makes the code cleaner.
- Use list comprehensions instead of for-loops to transform lists. [This is more performant](https://docs.astral.sh/ruff/rules/manual-list-comprehension/).