### PR TITLE
Solving typo on cell complex documentation.

### DIFF
--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -53,7 +53,7 @@ class TestGraphToSimplicialComplex:
         assert sc[(0,)]["label"] == 5
         assert sc[(0, 1)]["weight"] == 10
 
-        sc = graph_to_clique_complex(G, max_dim=2)
+        sc = graph_to_clique_complex(G, max_dim=1)
 
         assert sc.dim == 1
         assert (0, 2, 3) not in sc

--- a/test/transform/test_graph_to_simplicial_complex.py
+++ b/test/transform/test_graph_to_simplicial_complex.py
@@ -93,7 +93,7 @@ class TestGraphToSimplicialComplex:
         assert (0, 1, 2) in sc
 
         with pytest.deprecated_call():
-            sc = graph_2_clique_complex(G, max_dim=2)
+            sc = graph_2_clique_complex(G, max_dim=1)
 
         assert sc.dim == 1
         assert (0, 2, 3) not in sc

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -1877,7 +1877,7 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        rank : {0, 1}
+        rank : {1, 2}
             Rank of the down Laplacian matrix.
         signed : bool
             Whether to return the signed or unsigned down laplacian.

--- a/toponetx/transform/graph_to_simplicial_complex.py
+++ b/toponetx/transform/graph_to_simplicial_complex.py
@@ -60,15 +60,17 @@ def graph_to_clique_complex(
     # `nx.enumerate_all_cliques` returns cliques in ascending order of size. Abort calling the generator once we reach
     # cliques larger than the requested max dimension.
     if max_dim is not None:
-        cliques = takewhile(lambda clique: len(clique) <= max_dim, cliques)
+        cliques = takewhile(lambda clique: len(clique) <= max_dim + 1, cliques)
 
     SC = SimplicialComplex(cliques)
 
     # copy attributes of the input graph
     for node in G.nodes:
         SC[[node]].update(G.nodes[node])
-    for edge in G.edges:
-        SC[edge].update(G.edges[edge])
+    # if the resulting complex has dimension 1 or higher, copy the attributes of the edges
+    if SC.dim >= 1:
+        for edge in G.edges:
+            SC[edge].update(G.edges[edge])
     SC.complex.update(G.graph)
 
     return SC


### PR DESCRIPTION
Previously, the method down_laplacian_matrix was indicating that the possible values were {0, 1} were the actual possible values are {0, 2}.