### PR TITLE
 Solving typo on cell complex documentation. #338 

### DIFF
--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -1877,7 +1877,7 @@ class CellComplex(Complex):
 
         Parameters
         ----------
-        rank : {0, 1}
+        rank : {1, 2}
             Rank of the down Laplacian matrix.
         signed : bool
             Whether to return the signed or unsigned down laplacian.


### PR DESCRIPTION
Previously, the method down_laplacian_matrix was indicating that the possible values were {0, 1} were the actual possible values are {1, 2}.