### PR TITLE
Raise an exception for distances between non-connected elements.

### DIFF
--- a/test/algorithms/test_distance.py
+++ b/test/algorithms/test_distance.py
@@ -8,6 +8,7 @@ from toponetx.classes.cell_complex import CellComplex
 from toponetx.classes.combinatorial_complex import CombinatorialComplex
 from toponetx.classes.hyperedge import HyperEdge
 from toponetx.classes.simplicial_complex import SimplicialComplex
+from toponetx.exception import TopoNetXNoPath
 
 
 class TestDistance:
@@ -15,16 +16,12 @@ class TestDistance:
 
     def test_distance(self):
         """Test for the distance method."""
-        CC = CellComplex()  # Initialize your class object
+        CC = CellComplex()
 
-        # Add some cells to the complex
         CC.add_cell([2, 3, 4], rank=2)
         CC.add_cell([5, 6, 7], rank=2)
 
-        # Test the function
-        result = distance(CC, 2, 3)
-        expected_result = 1
-        assert result == expected_result
+        assert distance(CC, 2, 3) == 1
 
     def test_distance_edgecases(self):
         """Test the distance method to check exceptions."""
@@ -33,34 +30,30 @@ class TestDistance:
         CCC.add_cell([2, 3, 4], rank=2)
         CCC.add_cell([5, 6, 7], rank=2)
 
-        with pytest.warns():
-            distance(CCC, 2, 3)
+        with pytest.raises(TopoNetXNoPath):
+            distance(CCC, 2, 5)
 
-        with pytest.warns():
+        with pytest.raises(KeyError):
             distance(CCC, [2, 3, 4], [5, 6, 7])
 
-        with pytest.warns():
+        with pytest.raises(KeyError):
             distance(CCC, Cell([2, 3, 4]), Cell([5, 6, 7]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             distance(1, 2, 3)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             distance(SimplicialComplex(), 2, 3)
 
     def test_cell_distance(self):
         """Test for the cell_distance method."""
-        CC = CellComplex()  # Initialize your class object
+        CC = CellComplex()
 
-        # Add some cells to the complex
         CC.add_cell([2, 3, 4], rank=2)
         CC.add_cell([5, 6, 7], rank=2)
         CC.add_cell([2, 5], rank=1)
 
-        # Test the function
-        result = cell_distance(CC, (2, 3, 4), (5, 6, 7))
-        expected_result = 2
-        assert result == expected_result
+        assert cell_distance(CC, (2, 3, 4), (5, 6, 7)) == 2
 
     def test_cell_distance_edgecases(self):
         """Test for cell_distance with exceptions."""
@@ -69,17 +62,17 @@ class TestDistance:
         CCC.add_cell([2, 3, 4], rank=2)
         CCC.add_cell([5, 6, 7], rank=2)
 
-        with pytest.warns():
-            cell_distance(CCC, 2, 3)
+        with pytest.raises(TopoNetXNoPath):
+            cell_distance(CCC, (2, 3, 4), (5, 6, 7))
 
-        with pytest.warns():
-            cell_distance(CCC, [2, 3, 4], [5, 6, 7])
+        with pytest.raises(KeyError):
+            cell_distance(CCC, [3, 4, 5], [5, 6, 7])
 
-        with pytest.warns():
-            cell_distance(CCC, HyperEdge([2, 3, 4]), HyperEdge([5, 6, 7]))
+        with pytest.raises(KeyError):
+            cell_distance(CCC, HyperEdge([3, 4, 5]), HyperEdge([5, 6, 7]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             cell_distance(1, 2, 3)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             cell_distance(SimplicialComplex(), 2, 3)

--- a/toponetx/algorithms/components.py
+++ b/toponetx/algorithms/components.py
@@ -115,12 +115,8 @@ def s_connected_components(
 
     else:
         node_dict, A = domain.node_to_all_cell_adjacnecy_matrix(s=s, index=True)
-        if isinstance(domain, ColoredHyperGraph) and not isinstance(
-            domain, CombinatorialComplex
-        ):
-            node_dict = {v: k[0] for k, v in node_dict.items()}
-        else:
-            node_dict = {v: k for k, v in node_dict.items()}
+        node_dict = {v: k for k, v in node_dict.items()}
+
         G = nx.from_scipy_sparse_array(A)
         for c in nx.connected_components(G):
             if not return_singletons and len(c) == 1:

--- a/toponetx/algorithms/distance_measures.py
+++ b/toponetx/algorithms/distance_measures.py
@@ -41,12 +41,7 @@ def node_diameters(domain: ComplexType) -> tuple[list[int], list[set[Hashable]]]
     >>> list(node_diameters(CHG))
     """
     node_dict, A = domain.node_to_all_cell_adjacnecy_matrix(index=True)
-    if isinstance(domain, ColoredHyperGraph) and not isinstance(
-        domain, CombinatorialComplex
-    ):
-        node_dict = {v: k[0] for k, v in node_dict.items()}
-    else:
-        node_dict = {v: k for k, v in node_dict.items()}
+    node_dict = {v: k for k, v in node_dict.items()}
 
     G = nx.from_scipy_sparse_array(A)
     diams = []

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -1177,6 +1177,14 @@ class ColoredHyperGraph(Complex):
             lower (row) index dict, upper (col) index dict, incidence matrix
             where the index dictionaries map from the entity (as `Hashable` or `tuple`) to the row or col index of the matrix.
         """
+        if index:
+            (
+                row_indices,
+                col_indices,
+                incidence_matrix,
+            ) = self.all_ranks_incidence_matrix(0, weight=weight, index=index)
+            row_indices = {next(iter(k)): v for k, v in row_indices.items()}
+            return row_indices, col_indices, incidence_matrix
         return self.all_ranks_incidence_matrix(0, weight=weight, index=index)
 
     def all_ranks_incidence_matrix(

--- a/toponetx/exception.py
+++ b/toponetx/exception.py
@@ -1,0 +1,24 @@
+"""Base errors and exceptions for TopoNetX."""
+
+__all__ = [
+    "TopoNetXException",
+    "TopoNetXAlgorithmError",
+    "TopoNetXUnfeasible",
+    "TopoNetXNoPath",
+]
+
+
+class TopoNetXException(Exception):
+    """Base class for exceptions in TopoNetX."""
+
+
+class TopoNetXAlgorithmError(TopoNetXException):
+    """Exception that is raised if an algorithm terminates unexpectedly."""
+
+
+class TopoNetXUnfeasible(TopoNetXAlgorithmError):
+    """Exception raised by algorithms trying to solve a problem instance that has no feasible solution."""
+
+
+class TopoNetXNoPath(TopoNetXUnfeasible):
+    """Exception for algorithms that should return a path or path length where such a path does not exist."""


### PR DESCRIPTION
Previously, the distance between non-connected elements was set to `np.inf`.  See #343 for reasons why this a bad idea. Following NetworkX, in these cases we now raise a new `TopoNetXNoPathException`.

The previous implementation also silently swallowed too many exceptions and returned infinity, which also swallowed actual implementation errors. They have been fixed with this pull request.

Closes #343.