### PR TITLE
fixng a bug in CCC

### DIFF
--- a/test/classes/test_combinatorial_complex.py
+++ b/test/classes/test_combinatorial_complex.py
@@ -73,6 +73,24 @@ class TestCombinatorialComplex:
 
         assert "a" in CCC.cells
 
+    def test_node_membership(self):
+        """Test creation of _node_membership dictionary."""
+        CCC = CombinatorialComplex()
+        CCC.add_cell([1, 2, 3], rank=1)
+        CCC.add_cell([1, 2, 3, 4], rank=2)
+
+        assert 1 in CCC._node_membership
+        assert 2 in CCC._node_membership
+        assert 3 in CCC._node_membership
+        assert 4 in CCC._node_membership
+        assert frozenset({1, 2, 3, 4}) in CCC._node_membership[1]
+        assert frozenset({1, 2, 3}) in CCC._node_membership[1]
+        assert frozenset({1, 2, 3, 4}) in CCC._node_membership[2]
+        assert frozenset({1, 2, 3}) in CCC._node_membership[2]
+        assert frozenset({1, 2, 3, 4}) in CCC._node_membership[3]
+        assert frozenset({1, 2, 3}) in CCC._node_membership[3]
+        assert frozenset({1, 2, 3, 4}) in CCC._node_membership[4]
+
     def test_add_cell(self):
         """Test adding a cell to a CCC."""
         CCC = CombinatorialComplex()

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -558,6 +558,10 @@ class CombinatorialComplex(ColoredHyperGraph):
         else:
             self._complex_set.hyperedge_dict[rank][hyperedge_].update(**attr)
         self._add_nodes_of_hyperedge(hyperedge_)
+        for i in hyperedge_:
+            if i not in self._node_membership:
+                self._node_membership[i] = set()
+            self._node_membership[i].add(hyperedge_)
 
     def _CCC_condition(self, hyperedge_, rank):
         """Check if hyperedge_ satisfies the CCC condition.


### PR DESCRIPTION
The CCC condition is not being checked correctly when inserting a new cell. Bug fixed with this PR. See #315.

 Also added a new test to insure this the membership dictionary is being populated correctly, this is implemented to prevent deleting the parts of the code responsible for taking into account this feature. 