### PR TITLE
Use `Self` return type where applicable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies=[
     "requests",
     "scipy",
     "trimesh",
+    "typing-extensions",
     "spharapy",
 ]
 

--- a/toponetx/classes/cell.py
+++ b/toponetx/classes/cell.py
@@ -5,6 +5,8 @@ from collections.abc import Collection, Hashable, Iterable, Sequence
 from itertools import zip_longest
 from typing import Literal
 
+from typing_extensions import Self
+
 from toponetx.classes.complex import Atom
 
 __all__ = ["Cell"]
@@ -85,7 +87,7 @@ class Cell(Atom[tuple[Hashable]]):
                         f"self loops are not permitted, got {(e[0],e[1])} as an edge in the cell's boundary"
                     )
 
-    def clone(self) -> "Cell":
+    def clone(self) -> Self:
         """Clone the Cell with all attributes.
 
         The clone method by default returns an independent shallow copy of the cell and
@@ -97,7 +99,7 @@ class Cell(Atom[tuple[Hashable]]):
         Cell
             A copy of this cell.
         """
-        return Cell(self.elements, self._regular, **self._attributes)
+        return self.__class__(self.elements, self._regular, **self._attributes)
 
     @staticmethod
     def is_valid_cell(elements: Sequence, regular: bool = False) -> bool:

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -19,6 +19,7 @@ import scipy.sparse
 from networkx import Graph
 from networkx.classes.reportviews import EdgeView, NodeView
 from networkx.utils import pairwise
+from typing_extensions import Self
 
 from toponetx.classes.cell import Cell
 from toponetx.classes.combinatorial_complex import (
@@ -2294,7 +2295,7 @@ class CellComplex(Complex):
         """
         return [node for node in self.nodes if self.degree(node) == 0]
 
-    def clone(self) -> "CellComplex":
+    def clone(self) -> Self:
         """Create a clone of the CellComplex.
 
         Returns
@@ -2312,7 +2313,7 @@ class CellComplex(Complex):
         >>> CX2 = CC.clone()
         """
         _G = self._G.copy()
-        CC = CellComplex(_G)
+        CC = self.__class__(_G)
         for cell in self.cells:
             CC.add_cell(cell.clone())
         return CC
@@ -2427,7 +2428,7 @@ class CellComplex(Complex):
             self.add_node(node)
 
     @classmethod
-    def from_trimesh(cls, mesh) -> "CellComplex":
+    def from_trimesh(cls, mesh) -> Self:
         """Convert from trimesh object.
 
         Parameters
@@ -2468,7 +2469,7 @@ class CellComplex(Complex):
         return CC
 
     @classmethod
-    def load_mesh(cls, file_path, process: bool = False) -> "CellComplex":
+    def load_mesh(cls, file_path, process: bool = False) -> Self:
         """Load a mesh.
 
         Parameters

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.sparse
 import trimesh
 from scipy.sparse import csr_array, diags
+from typing_extensions import Self
 
 from toponetx.classes.complex import Complex
 from toponetx.classes.hyperedge import HyperEdge
@@ -472,7 +473,7 @@ class ColoredHyperGraph(Complex):
             raise KeyError(f"node {node} not in {self.__shortstr__}")
         self._remove_node_helper(node)
 
-    def remove_node(self, node):
+    def remove_node(self, node) -> Self:
         """Remove a node from the ColoredHyperGraph.
 
         This method removes a node from the cells and deletes any reference in the nodes of the CHG.
@@ -1565,7 +1566,7 @@ class ColoredHyperGraph(Complex):
         cells = [cell for cell in self.cells if cell not in self.singletons()]
         return self.restrict_to_cells(cells)
 
-    def clone(self) -> "ColoredHyperGraph":
+    def clone(self) -> Self:
         """Return a copy of the simplex.
 
         The clone method by default returns an independent shallow copy of the simplex
@@ -1578,7 +1579,7 @@ class ColoredHyperGraph(Complex):
         ColoredHyperGraph
             ColoredHyperGraph.
         """
-        CHG = ColoredHyperGraph()
+        CHG = self.__class__()
         for cell, key in self.cells:
             CHG.add_cell(cell, key=key, rank=self.cells.get_rank(cell))
         return CHG

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -4,6 +4,7 @@ from collections.abc import Collection, Hashable, Iterable
 from typing import Any, Literal
 
 import networkx as nx
+from typing_extensions import Self
 
 from toponetx.classes.colored_hypergraph import ColoredHyperGraph
 from toponetx.classes.complex import Complex
@@ -1077,7 +1078,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         """
         super().remove_cells(cell_set)
 
-    def clone(self) -> "CombinatorialComplex":
+    def clone(self) -> Self:
         """Return a copy of the simplex.
 
         The clone method by default returns an independent shallow copy of the simplex
@@ -1090,7 +1091,7 @@ class CombinatorialComplex(ColoredHyperGraph):
         CombinatorialComplex
             A copy of this combinatorial complex.
         """
-        CCC = CombinatorialComplex(graph_based=self.graph_based)
+        CCC = self.__class__(graph_based=self.graph_based)
         for cell in self.cells:
             CCC.add_cell(cell, self.cells.get_rank(cell))
         return CCC

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -1,9 +1,10 @@
 """Abstract class for Complex and Atom."""
 
-
 import abc
 from collections.abc import Collection, Hashable, Iterator
 from typing import Any, Generic, TypeVar
+
+from typing_extensions import Self
 
 __all__ = ["Atom", "Complex"]
 
@@ -227,7 +228,7 @@ class Complex(abc.ABC):
         """Return number of nodes."""
 
     @abc.abstractmethod
-    def clone(self) -> "Complex":
+    def clone(self) -> Self:
         """Clone complex."""
 
     @abc.abstractmethod

--- a/toponetx/classes/path.py
+++ b/toponetx/classes/path.py
@@ -3,6 +3,8 @@
 from collections.abc import Hashable, Iterable, Sequence
 from typing import Any
 
+from typing_extensions import Self
+
 from toponetx.classes.complex import Atom
 
 __all__ = ["Path"]
@@ -167,7 +169,7 @@ class Path(Atom[tuple[Hashable]]):
         """
         return self._boundaries
 
-    def clone(self) -> "Path":
+    def clone(self) -> Self:
         """Return a shallow copy of the elementary p-path.
 
         Returns
@@ -175,7 +177,7 @@ class Path(Atom[tuple[Hashable]]):
         Path
             A shallow copy of the elementary p-path.
         """
-        return Path(
+        return self.__class__(
             self.elements,
             construct_boundaries=self.construct_boundaries,
             **self._attributes,

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -1,4 +1,5 @@
 """Path complex."""
+
 from collections.abc import Hashable, Iterable, Iterator, Sequence
 from typing import Any
 
@@ -6,6 +7,7 @@ import networkx as nx
 import numpy as np
 import scipy as sp
 from networkx.classes.reportviews import EdgeView, NodeView
+from typing_extensions import Self
 
 from toponetx.classes.complex import Complex
 from toponetx.classes.path import Path
@@ -313,7 +315,7 @@ class PathComplex(Complex):
         """
         return self._path_set.shape
 
-    def clone(self) -> "PathComplex":
+    def clone(self) -> Self:
         """Return a copy of the path complex.
 
         The clone method by default returns an independent shallow copy of the path
@@ -324,7 +326,7 @@ class PathComplex(Complex):
         PathComplex
             Returns a copy of the PathComplex.
         """
-        return PathComplex(list(self.paths), rank=self.dim)
+        return self.__class__(list(self.paths), rank=self.dim)
 
     def skeleton(self, rank: int) -> list[tuple[Hashable]]:
         """Compute skeleton.

--- a/toponetx/classes/simplex.py
+++ b/toponetx/classes/simplex.py
@@ -5,6 +5,8 @@ from collections.abc import Collection, Hashable, Iterable
 from itertools import combinations
 from typing import Any
 
+from typing_extensions import Self
+
 from toponetx.classes.complex import Atom
 
 __all__ = ["Simplex"]
@@ -191,7 +193,7 @@ class Simplex(Atom[frozenset[Hashable]]):
         """
         return f"Nodes set: {tuple(self.elements)}, attrs: {self._attributes}"
 
-    def clone(self) -> "Simplex":
+    def clone(self) -> Self:
         """Return a copy of the simplex.
 
         The clone method by default returns an independent shallow copy of the simplex
@@ -204,4 +206,4 @@ class Simplex(Atom[frozenset[Hashable]]):
         Simplex
             A copy of this simplex.
         """
-        return Simplex(self.elements, **self._attributes)
+        return self.__class__(self.elements, **self._attributes)

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -12,6 +12,7 @@ import networkx as nx
 import numpy as np
 from gudhi import SimplexTree
 from scipy.sparse import csr_matrix, dok_matrix
+from typing_extensions import Self
 
 from toponetx.classes.complex import Complex
 from toponetx.classes.reportviews import NodeView, SimplexView
@@ -1307,7 +1308,7 @@ class SimplicialComplex(Complex):
 
         self.add_simplices_from(_simplices)
 
-    def restrict_to_simplices(self, cell_set) -> "SimplicialComplex":
+    def restrict_to_simplices(self, cell_set) -> Self:
         """Construct a simplicial complex using a subset of the simplices.
 
         Parameters
@@ -1332,7 +1333,7 @@ class SimplicialComplex(Complex):
         SimplexView([(1,), (2,), (3,), (4,), (1, 2), (1, 3), (2, 3), (2, 4), (1, 2, 3)])
         """
         rns = [cell for cell in cell_set if cell in self]
-        return SimplicialComplex(simplices=rns)
+        return self.__class__(simplices=rns)
 
     def restrict_to_nodes(self, node_set):
         """Construct a new simplicial complex by restricting the simplices.
@@ -1389,7 +1390,7 @@ class SimplicialComplex(Complex):
         return [tuple(s) for s in self.simplices if self.is_maximal(s)]
 
     @classmethod
-    def from_spharpy(cls, mesh) -> "SimplicialComplex":
+    def from_spharpy(cls, mesh) -> Self:
         """Import from sharpy.
 
         Parameters
@@ -1453,7 +1454,7 @@ class SimplicialComplex(Complex):
         return G
 
     @classmethod
-    def from_gudhi(cls, tree: SimplexTree) -> "SimplicialComplex":
+    def from_gudhi(cls, tree: SimplexTree) -> Self:
         """Import from gudhi.
 
         Parameters
@@ -1479,7 +1480,7 @@ class SimplicialComplex(Complex):
         return SC
 
     @classmethod
-    def from_trimesh(cls, mesh) -> "SimplicialComplex":
+    def from_trimesh(cls, mesh) -> Self:
         """Import from trimesh.
 
         Parameters
@@ -1523,7 +1524,7 @@ class SimplicialComplex(Complex):
         return SC
 
     @classmethod
-    def load_mesh(cls, file_path, process: bool = False) -> "SimplicialComplex":
+    def load_mesh(cls, file_path, process: bool = False) -> Self:
         """Load a mesh.
 
         Parameters
@@ -1667,7 +1668,7 @@ class SimplicialComplex(Complex):
         return mesh.laplacianmatrix(mode=mode)
 
     @classmethod
-    def from_nx(cls, G: nx.Graph) -> "SimplicialComplex":
+    def from_nx(cls, G: nx.Graph) -> Self:
         """Convert from netwrokx graph.
 
         Parameters
@@ -1711,7 +1712,7 @@ class SimplicialComplex(Complex):
         return nx.is_connected(G)
 
     @classmethod
-    def simplicial_closure_of_hypergraph(cls, H) -> "SimplicialComplex":
+    def simplicial_closure_of_hypergraph(cls, H) -> Self:
         """Compute the simplicial complex closure of a hypergraph.
 
         Parameters
@@ -1822,7 +1823,7 @@ class SimplicialComplex(Complex):
             G.add_edge(*edge, **self[edge])
         return G
 
-    def clone(self) -> "SimplicialComplex":
+    def clone(self) -> Self:
         """Return a copy of the simplicial complex.
 
         The clone method by default returns an independent shallow copy of the
@@ -1833,4 +1834,4 @@ class SimplicialComplex(Complex):
         SimplicialComplex
             A shallow copy of this simplicial complex.
         """
-        return SimplicialComplex(self.simplices)
+        return self.__class__(self.simplices)


### PR DESCRIPTION
The `Self` return type has been introduced in Python 3.11. It allows to express that the return type is of the current enclosed class while correctly considering subclasses.

As usual, the `Self` type is backported to older versions of Python in `typing-extensions`. We can use the native implementation `typing.Self` once Python 3.11+ is the minimum version.