### PR TITLE
Remove `wheel` from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
As [recommended by Scientific Python](https://learn.scientific-python.org/development/guides/packaging-classic/#PP003), `wheel` should not be part of the build dependencies. It is injected automatically by setuptools when needed.