### PR TITLE
Clean-up ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ homepage="https://github.com/pyt-team/TopoNetX"
 repository="https://github.com/pyt-team/TopoNetX"
 
 [tool.ruff]
-target-version = "py310"
 extend-include = ["*.ipynb"]
 
 [tool.ruff.format]
@@ -103,11 +102,11 @@ ignore = [
     "PERF203", # allow try-except within loops
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F403"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F403"]
 
 [tool.setuptools.dynamic]
 version = {attr = "toponetx.__version__"}


### PR DESCRIPTION
- Do not specify Python `target-version` for ruff, it is automatically taken from the project's minimum version.
- `per-file-ignores` moved to the `lint` section.