### PR TITLE
Update mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,8 +119,9 @@ include = [
 
 [tool.mypy]
 warn_redundant_casts = true
+warn_unreachable = true
 warn_unused_ignores = true
-show_error_codes = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 disable_error_code = ["import-untyped"]
 plugins = "numpy.typing.mypy_plugin"
 


### PR DESCRIPTION
- `show_error_codes` is the default since a few mypy versions.
- Add stricter rules as suggested by scientific python: https://learn.scientific-python.org/development/guides/style/#MY104