### PR TITLE
Consistent dunder methods for all complexes

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -808,8 +808,18 @@ class TestCellComplex:
         """Test the iterator of the cell complex."""
         CC = CellComplex()
         CC.add_cell([1, 2, 3], rank=2)
-        CC.add_cell([2, 3, 4], rank=2)
-        assert set(iter(CC)) == {1, 2, 3, 4}
+        CC.add_cell([2, 4], rank=1)
+        assert set(CC) == {
+            (1,),
+            (2,),
+            (3,),
+            (4,),
+            (2, 1),
+            (2, 3),
+            (3, 1),
+            (2, 4),
+            (1, 2, 3),
+        }
 
     def test_cell_equivalence_class(self):
         """Test the cell equivalence class method."""

--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -1571,10 +1571,19 @@ class TestCellComplex:
     def test_getitem_dunder_method(self):
         """Test if the dunder __getitem__ method returns the appropriate neighbors of the given node."""
         CC = CellComplex()
-        CC.add_edges_from([(1, 2), (2, 3), (5, 2), (1, 9), (1, 6)])
-        assert sorted(CC.__getitem__(1)) == [2, 6, 9]
-        assert sorted(CC.__getitem__(2)) == [1, 3, 5]
-        assert sorted(CC.__getitem__(6)) == [1]
+        CC.add_node(1, color="red")
+        CC.add_edge(1, 2, weight=10)
+        CC.add_cell((2, 3, 4), rank=2, weight=5)
+
+        assert CC[1]["color"] == "red"
+        assert CC[(1, 2)]["weight"] == 10
+        assert CC[(2, 3, 4)]["weight"] == 5
+
+        with pytest.raises(KeyError):
+            _ = CC[5]
+
+        CC[(1, 2)]["new"] = 1
+        assert CC[(1, 2)]["new"] == 1
 
     def test_remove_nodes(self):
         """Test remove nodes method of the class Cell Complex."""

--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -1576,6 +1576,7 @@ class TestCellComplex:
         CC.add_cell((2, 3, 4), rank=2, weight=5)
 
         assert CC[1]["color"] == "red"
+        assert CC[(1,)]["color"] == "red"
         assert CC[(1, 2)]["weight"] == 10
         assert CC[(2, 3, 4)]["weight"] == 5
 

--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -1253,7 +1253,7 @@ class TestCellComplex:
         CC.remove_singletons()
         assert CC.singletons() == []
 
-    def test_contains__(self):
+    def test_contains(self):
         """Test __contains__."""
         CC = CellComplex()
         CC.add_cell([1, 2, 3, 4], rank=2)
@@ -1264,6 +1264,10 @@ class TestCellComplex:
         assert 3 in CC
         assert 4 in CC
         assert 5 in CC
+        assert 10 not in CC
+        assert (1, 2) in CC
+        assert (10, 12) not in CC
+        assert (1, 2, 3, 4) in CC
         assert (1, 2, 3, 4, 5) not in CC
 
     def test_neighbors(self):

--- a/test/classes/test_colored_hypergraph.py
+++ b/test/classes/test_colored_hypergraph.py
@@ -128,16 +128,6 @@ class TestColoredHyperGraph:
         CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
         assert CHG[1] == {"weight": 1}
 
-    def test_chg_set(self):
-        """Test chg set node properties."""
-        CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
-        assert CHG[1] == {"weight": 1}
-        CHG.__setitem__(1, weight=2)
-        assert CHG[1] == {"weight": 2}
-
-        with pytest.raises(KeyError):
-            CHG[5]
-
     def test_add_cell(self):
         """Test adding a cell to a CHG."""
         CHG = ColoredHyperGraph()

--- a/test/classes/test_colored_hypergraph.py
+++ b/test/classes/test_colored_hypergraph.py
@@ -126,7 +126,30 @@ class TestColoredHyperGraph:
     def test_chg_getitem(self):
         """Test chg get node properties."""
         CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
+        CHG.add_cell([5, 6], capacity=10)
+        CHG.add_cell([5, 6], key=1, capacity=15)
+        CHG.add_cell([5, 6, 7], capacity=5)
+
         assert CHG[1] == {"weight": 1}
+        assert CHG[(5, 6)]["capacity"] == 10
+        assert CHG[HyperEdge([5, 6])]["capacity"] == 10
+        assert CHG[(5, 6, 7)]["capacity"] == 5
+        assert CHG[HyperEdge([5, 6, 7])]["capacity"] == 5
+
+        assert CHG[((5, 6), 0)]["capacity"] == 10
+        assert CHG[(HyperEdge([5, 6]), 1)]["capacity"] == 15
+
+        # non-existing hyperedges
+        with pytest.raises(KeyError):
+            _ = CHG[(0, 1, 2)]
+        with pytest.raises(KeyError):
+            _ = CHG[((5, 6), 2)]
+
+        # invalid inputs should raise `KeyError`s as well
+        with pytest.raises(KeyError):
+            _ = CHG[tuple()]
+        with pytest.raises(KeyError):
+            _ = CHG[(tuple(), 0)]
 
     def test_add_cell(self):
         """Test adding a cell to a CHG."""

--- a/test/classes/test_colored_hypergraph.py
+++ b/test/classes/test_colored_hypergraph.py
@@ -1,7 +1,5 @@
 """Unit tests for the colored hypergraph class."""
 
-import collections
-
 import networkx as nx
 import pytest
 from scipy.sparse import csr_array
@@ -103,14 +101,14 @@ class TestColoredHyperGraph:
     def test_chg_iter(self):
         """Test CHG iter."""
         CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
-        isinstance(CHG, collections.abc.Iterable)
-        it = iter(CHG)
-        assert next(it) == frozenset({1})
-        assert next(it) == frozenset({2})
-        assert next(it) == frozenset({3})
-        assert next(it) == frozenset({4})
-        with pytest.raises(StopIteration):
-            next(it)
+        assert set(CHG) == {
+            frozenset({1}),
+            frozenset({2}),
+            frozenset({3}),
+            frozenset({4}),
+            frozenset({1, 2, 3}),
+            frozenset({2, 3, 4}),
+        }
 
     def test_chg_contains(self):
         """Test chg contains property."""

--- a/test/classes/test_colored_hypergraph.py
+++ b/test/classes/test_colored_hypergraph.py
@@ -10,8 +10,8 @@ from toponetx.classes.colored_hypergraph import ColoredHyperGraph
 from toponetx.classes.hyperedge import HyperEdge
 
 
-class TestCombinatorialComplex:
-    """Test CombinatorialComplex class."""
+class TestColoredHyperGraph:
+    """Test ColoredHyperGraph class."""
 
     def test_init_empty_chg(self):
         """Test creation of an empty CHG."""
@@ -115,11 +115,15 @@ class TestCombinatorialComplex:
     def test_chg_contains(self):
         """Test chg contains property."""
         CHG = ColoredHyperGraph([[1, 2, 3], [2, 3, 4]], ranks=2)
+
         assert 1 in CHG
         assert 2 in CHG
         assert 3 in CHG
         assert 4 in CHG
         assert 5 not in CHG
+
+        assert (1, 2) not in CHG
+        assert (1, 2, 3) in CHG
 
     def test_chg_getitem(self):
         """Test chg get node properties."""

--- a/test/classes/test_combinatorial_complex.py
+++ b/test/classes/test_combinatorial_complex.py
@@ -359,6 +359,14 @@ class TestCombinatorialComplex:
         CCC.add_cell([1, 2, 4, 3], rank=2)
         CCC.add_cell([2, 5], rank=1)
         CCC.add_cell([2, 6, 4], rank=2)
+
+        assert 1 in CCC
+        assert 3 in CCC
+        assert 7 not in CCC
+
+        assert (1, 2) in CCC
+        assert (1, 4) not in CCC
+
         assert [(1)] in CCC.nodes
         assert [2] in CCC.nodes
         assert [3] in CCC.nodes

--- a/test/classes/test_path_complex.py
+++ b/test/classes/test_path_complex.py
@@ -97,6 +97,17 @@ class TestPathComplex:
         assert [1, 2] in PC.paths
         assert [2, 3] in PC.paths
 
+    def test_contains(self):
+        """Test the __contains__ method."""
+        PC = PathComplex([[1, 2], [3], [4]])
+        assert 1 in PC
+        assert 3 in PC
+        assert 5 not in PC
+
+        with pytest.deprecated_call():
+            assert (1, 2) in PC
+            assert (1, 3) not in PC
+
     def test_constructor_using_graph(self):
         """Test constructor using graph."""
         G = nx.Graph()

--- a/test/classes/test_path_complex.py
+++ b/test/classes/test_path_complex.py
@@ -100,13 +100,13 @@ class TestPathComplex:
     def test_contains(self):
         """Test the __contains__ method."""
         PC = PathComplex([[1, 2], [3], [4]])
+
         assert 1 in PC
         assert 3 in PC
         assert 5 not in PC
 
-        with pytest.deprecated_call():
-            assert (1, 2) in PC
-            assert (1, 3) not in PC
+        assert (1, 2) in PC
+        assert (1, 3) not in PC
 
     def test_constructor_using_graph(self):
         """Test constructor using graph."""
@@ -302,7 +302,7 @@ class TestPathComplex:
         """Test get size of the path complex."""
         PC = PathComplex()
         PC.add_paths_from([[1, 2, 3], [1, 2, 4]])
-        assert len(PC) == 4
+        assert len(PC) == 9
 
     def test_add_paths_from(self):
         """Test add paths from graph."""

--- a/test/classes/test_reportviews.py
+++ b/test/classes/test_reportviews.py
@@ -525,19 +525,19 @@ class TestReportViews_ColoredHyperEdgeView:
     def test_contains(self):
         """Test the contains method."""
         assert ((1, 2), 0) in self.colorhg_view
-        assert self.colorhg_view.__contains__([]) is False
-        assert self.colorhg_view.__contains__(((2, 3), 0)) is True
-        assert self.colorhg_view.__contains__(1) is False
-        assert self.colorhg_view.__contains__(([], 1)) is False
-        assert self.colorhg_view.__contains__(((5, 6), 0)) is False
-        assert self.colorhg_view.__contains__(HyperEdge([1, 2])) is True
-        assert self.colorhg_view.__contains__((HyperEdge([1, 2, 3]), 0)) is False
-        assert self.colorhg_view.__contains__((HyperEdge([1, 2]), 0)) is True
-        assert self.colorhg_view.__contains__((HyperEdge([]), 0)) is False
+        assert [] not in self.colorhg_view
+        assert ((2, 3), 0) in self.colorhg_view
+        assert 1 in self.colorhg_view
+        assert ([], 1) not in self.colorhg_view
+        assert ((5, 6), 0) not in self.colorhg_view
+        assert HyperEdge([1, 2]) in self.colorhg_view
+        assert (HyperEdge([1, 2, 3]), 0) not in self.colorhg_view
+        assert (HyperEdge([1, 2]), 0) in self.colorhg_view
+        assert (HyperEdge([]), 0) not in self.colorhg_view
 
         # test for empty CHG
-        assert self.colorhg_view1.__contains__(HyperEdge([1, 2])) is False
-        assert self.colorhg_view1.__contains__([]) is False
+        assert HyperEdge([1, 2]) not in self.colorhg_view1
+        assert (HyperEdge([1, 2]), 0) not in self.colorhg_view1
 
     def test_skeleton(self):
         """Test the skeleton method of ColorHyperGraphView."""
@@ -651,14 +651,14 @@ class TestReportViews_PathView:
 
     def test_contains(self):
         """Test the __contains__ method of the PathView class."""
-        assert self.path_view.__contains__(1) is True
-        assert self.path_view.__contains__((1,)) is True
-        assert self.path_view.__contains__(Path(1)) is True
-        assert self.path_view.__contains__((1, 2, 3, 4)) is False
-        assert self.path_view.__contains__(Path((1, 2, 4))) is False
-        assert self.path_view.__contains__({(1, 2, 3)}) is False
-        assert self.path_view.__contains__([]) is False
-        assert self.path_view.__contains__(Path([1, 2, 3, 4])) is False
+        assert 1 in self.path_view
+        assert (1,) in self.path_view
+        assert Path(1) in self.path_view
+        assert (1, 2, 3, 4) not in self.path_view
+        assert Path((1, 2, 4)) not in self.path_view
+        assert {(1, 2, 3)} not in self.path_view
+        assert [] not in self.path_view
+        assert Path([1, 2, 3, 4]) not in self.path_view
 
     def test_repr(self):
         """Test __repr__ method of the PathView class."""

--- a/test/classes/test_reportviews.py
+++ b/test/classes/test_reportviews.py
@@ -504,9 +504,7 @@ class TestReportViews_ColoredHyperEdgeView:
 
     def test_getitem(self):
         """Test the getitem method of the ColoredHyperEdgeView class."""
-        assert self.colorhg_view.__getitem__(((1, 2), 0)) == {"weight": 1}
-        with pytest.raises(KeyError):
-            self.colorhg_view.__getitem__((1, 2))
+        assert self.colorhg_view[((1, 2), 0)] == {"weight": 1}
 
     def test_repr(self):
         """Test the repr method."""

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -118,16 +118,20 @@ class TestSimplicialComplex:
 
     def test_iter(self):
         """Test iter method."""
-        sc = SimplicialComplex([[1, 2, 3], [2, 3, 4], [0, 1]])
-        assert len(list(sc)) == 5
-        _i = iter(sc)
-        assert next(_i) == 1
-        assert next(_i) == 2
-        assert next(_i) == 3
-        assert next(_i) == 4
-        assert next(_i) == 0
-        with pytest.raises(StopIteration):
-            next(_i)
+        SC = SimplicialComplex([[1, 2, 3], [2, 4], [5]])
+        simplices = set(SC)
+        assert simplices == {
+            frozenset({1}),
+            frozenset({2}),
+            frozenset({3}),
+            frozenset({4}),
+            frozenset({5}),
+            frozenset({1, 2}),
+            frozenset({1, 3}),
+            frozenset({2, 3}),
+            frozenset({2, 4}),
+            frozenset({1, 2, 3}),
+        }
 
     def test_getittem__(self):
         """Test __getitem__ and __setitem__ methods."""

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -278,6 +278,17 @@ class TestSimplicialComplex:
         SC.add_simplex("test")
         assert ("test",) in SC.simplices
 
+    def test_contains(self):
+        """Test the __contains__ method."""
+        SC = SimplicialComplex([[1, 2], [3], [4]])
+
+        assert 1 in SC
+        assert 3 in SC
+        assert 5 not in SC
+
+        assert (1, 2) in SC
+        assert (1, 3) not in SC
+
     def test_remove_maximal_simplex(self):
         """Test remove_maximal_simplex method."""
         # create a SimplicialComplex object with a few simplices
@@ -304,7 +315,7 @@ class TestSimplicialComplex:
         c1 = Simplex((1, 2, 3, 4, 5))
         SC.add_simplex(c1)
         SC.remove_maximal_simplex((1, 2, 3, 4, 5))
-        assert (1, 2, 3, 4, 5) not in SC
+        assert (1, 2, 3, 4, 5) not in SC.simplices
 
         # check removal with Simplex
         SC = SimplicialComplex()
@@ -312,7 +323,7 @@ class TestSimplicialComplex:
         c1 = Simplex((1, 2, 3, 4, 5))
         SC.add_simplex(c1)
         SC.remove_maximal_simplex(c1)
-        assert (1, 2, 3, 4, 5) not in SC
+        assert (1, 2, 3, 4, 5) not in SC.simplices
 
         # check error when simplex not in complex
         with pytest.raises(KeyError):
@@ -331,12 +342,12 @@ class TestSimplicialComplex:
         SC = SimplicialComplex([[0, 1], [1, 2, 3], [2, 3, 4], [4, 5]])
         SC.remove_nodes([2, 5])
 
-        assert [0, 1] in SC
-        assert [1, 3] in SC
-        assert [3, 4] in SC
-        assert [4] in SC
-        assert [2, 3] not in SC
-        assert [2, 4] not in SC
+        assert [0, 1] in SC.simplices
+        assert [1, 3] in SC.simplices
+        assert [3, 4] in SC.simplices
+        assert [4] in SC.simplices
+        assert [2, 3] not in SC.simplices
+        assert [2, 4] not in SC.simplices
 
         assert SC.is_maximal([0, 1])
         assert SC.is_maximal([1, 3])
@@ -1019,7 +1030,7 @@ class TestSimplicialComplex:
         assert SC2[(1, 2, 3)] is not SC[(1, 2, 3)]
         SC2.remove_maximal_simplex([1, 2, 3])
         assert 1 in SC
-        assert (1, 2, 3) in SC
+        assert (1, 2, 3) in SC.simplices
 
     def test_normalized_laplacian_matrix(self):
         """Test the normalized_laplacian_matrix method of SimplicialComplex."""

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -134,17 +134,18 @@ class TestSimplicialComplex:
         }
 
     def test_getittem__(self):
-        """Test __getitem__ and __setitem__ methods."""
-        G = nx.Graph()
-        G.add_edge(0, 1)
-        G.add_edge(2, 5)
-        G.add_edge(5, 4, weight=5)
-        SC = SimplicialComplex(G, name="graph complex")
+        """Test __getitem__ methods."""
+        SC = SimplicialComplex()
+        SC.add_simplex((0, 1), weight=5)
         SC.add_simplex((1, 2, 3), heat=5)
-        # with pytest.raises(ValueError):
+
+        assert SC[(0, 1)]["weight"] == 5
         assert SC[(1, 2, 3)]["heat"] == 5
         with pytest.raises(KeyError):
             SC[(1, 2, 3, 4, 5)]["heat"]
+
+        SC[(0, 1)]["new"] = 10
+        assert SC[(0, 1)]["new"] == 10
 
     def test_setting_simplex_attributes(self):
         """Test setting simplex attributes through a `SimplicialComplex` object."""

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -338,7 +338,12 @@ class CellComplex(Complex):
         bool
             True if item is a cell of dim 0,1,2 is in the complex, False otherwise.
         """
-        return item in self.nodes
+        if not isinstance(item, Iterable):
+            return item in self._G.nodes
+
+        if len(item) == 2 and item in self._G.edges:
+            return True
+        return item in self._cells
 
     def __getitem__(self, node):
         """Return the neighbors of node.

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -7,7 +7,7 @@ A cell complex is abbreviated in CC.
 
 import warnings
 from collections import defaultdict
-from collections.abc import Hashable, Iterable, Iterator
+from collections.abc import Collection, Hashable, Iterable, Iterator
 from itertools import chain, zip_longest
 from typing import Any
 
@@ -349,20 +349,33 @@ class CellComplex(Complex):
             return True
         return item in self._cells
 
-    def __getitem__(self, node):
-        """Return the neighbors of node.
+    def __getitem__(self, atom: Any) -> dict[Hashable, Any]:
+        """Return the user-defined attributes associated with the given cell.
+
+        Writing to the returned dictionary will update the user-defined attributes
+        associated with the cell.
 
         Parameters
         ----------
-        node : hashable
-            The node contained in the cell complex.
+        atom : Any
+            The cell for which to return the associated user-defined attributes.
 
         Returns
         -------
-        Iterator
-            Iterator over neighbors of node.
+        dict[Hashable, Any]
+            The user-defined attributes associated with the given cell.
         """
-        return self.neighbors(node)
+        if isinstance(atom, Collection) and len(atom) == 1:
+            atom = next(iter(atom))
+
+        if not isinstance(atom, Iterable):
+            return self._G.nodes[atom]
+
+        atom = tuple(atom)
+        if len(atom) == 2 and atom in self._G.edges:
+            return self._G.edges[atom]
+
+        return self._cells[atom]
 
     def _insert_cell(self, cell: tuple | list | Cell, **attr):
         """Insert cell.

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -8,7 +8,7 @@ A cell complex is abbreviated in CC.
 import warnings
 from collections import defaultdict
 from collections.abc import Hashable, Iterable, Iterator
-from itertools import zip_longest
+from itertools import chain, zip_longest
 from typing import Any
 
 import networkx as nx
@@ -323,7 +323,11 @@ class CellComplex(Complex):
         dict_keyiterator
             Iterator over nodes.
         """
-        return iter(self.nodes)
+        return chain(
+            map(lambda x: (x,), self.nodes),
+            self.edges,
+            map(lambda cell: tuple(cell), self.cells),
+        )
 
     def __contains__(self, item) -> bool:
         """Return boolean indicating if item is in self.nodes, self.edges or self.cells.

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -2,6 +2,7 @@
 
 import contextlib
 from collections.abc import Collection, Hashable, Iterable
+from itertools import chain
 from typing import Any
 
 import networkx as nx
@@ -252,7 +253,13 @@ class ColoredHyperGraph(Complex):
         iterable
             Iterator over the nodes.
         """
-        return iter(self.nodes)
+        return chain(
+            self.nodes,
+            chain.from_iterable(
+                rank_hyperedges.keys()
+                for rank_hyperedges in self._complex_set.hyperedge_dict.values()
+            ),
+        )
 
     def __contains__(self, atom: Any) -> bool:
         """Check whether this colored hypergraph contains the given atom.

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -276,59 +276,28 @@ class ColoredHyperGraph(Complex):
         """
         return atom in self._complex_set
 
-    def __setitem__(self, cell, **attr):
-        """Set the attributes of a hyperedge or node in the ColoredHyperGraph.
+    def __getitem__(self, atom: Any) -> dict[Hashable, Any]:
+        """Return the user-defined attributes associated with the given atom.
+
+        Writing to the returned dictionary will update the user-defined attributes
+        associated with the atom.
 
         Parameters
         ----------
-        cell : Hashable or RankedEntity
-            The hyperedge or node for which attributes are to be set.
-        **attr : keyword arguments
-            Additional attributes to be set.
+        atom : Any
+            The atom for which to return the associated user-defined attributes.
 
         Returns
         -------
-        None
-            None.
+        dict[Hashable, Any]
+            The user-defined attributes associated with the given atom.
 
         Raises
         ------
         KeyError
-            If the input cell is not found in the ColoredHyperGraph.
+            If the atom does not exist in this complex.
         """
-        if cell in self.nodes:
-            self.nodes[cell].update(**attr)
-        # we now check if the input is a cell in the CHG
-        elif cell in self.cells:
-            hyperedge_ = ColoredHyperEdgeView._to_frozen_set(cell)
-            rank = self.cells.get_rank(hyperedge_)
-            if hyperedge_ in self._complex_set.hyperedge_dict[rank]:
-                self._complex_set.hyperedge_dict[rank][hyperedge_].update(**attr)
-
-        else:
-            raise KeyError(f"input {cell} is not in the complex")
-
-    def __getitem__(self, node):
-        """Return the attributes of a node.
-
-        Parameters
-        ----------
-        node : Hashable
-            The node for which attributes are to be retrieved.
-
-        Returns
-        -------
-        dict
-            Dictionary of attributes associated with the node.
-
-        Raises
-        ------
-        KeyError
-            If the input node is not found in the ColoredHyperGraph.
-        """
-        if node not in self.nodes:
-            raise KeyError(f"Node {node} is not in the complex.")
-        return self.nodes[node]
+        return self._complex_set[atom]
 
     def size(self, cell):
         """Compute the number of nodes in the colored hypergraph that belong to a specific cell.

--- a/toponetx/classes/colored_hypergraph.py
+++ b/toponetx/classes/colored_hypergraph.py
@@ -2,6 +2,7 @@
 
 import contextlib
 from collections.abc import Collection, Hashable, Iterable
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -253,20 +254,20 @@ class ColoredHyperGraph(Complex):
         """
         return iter(self.nodes)
 
-    def __contains__(self, item) -> bool:
-        """Check if an item is in the nodes or edges of the colored hypergraph.
+    def __contains__(self, atom: Any) -> bool:
+        """Check whether this colored hypergraph contains the given atom.
 
         Parameters
         ----------
-        item : hashable or HyperEdge
-            The item to check for existence.
+        atom : Any
+            The atom to be checked.
 
         Returns
         -------
         bool
-            True if the item is found, False otherwise.
+            Returns `True` if this colored hypergraph contains the atom, else `False`.
         """
-        return item in self.nodes
+        return atom in self._complex_set
 
     def __setitem__(self, cell, **attr):
         """Set the attributes of a hyperedge or node in the ColoredHyperGraph.

--- a/toponetx/classes/combinatorial_complex.py
+++ b/toponetx/classes/combinatorial_complex.py
@@ -26,7 +26,7 @@ class CombinatorialComplex(ColoredHyperGraph):
     The rank function $rk$ must satisfy $x \leq y$ then $rk(x) \leq rk(y)$.
     We call this condition the CCC condition.
 
-    A CCC is a generlization of graphs, hypergraphs, cellular and simplicial complexes.
+    A CCC is a generalization of graphs, hypergraphs, cellular and simplicial complexes.
 
     Mathematical Example:
 
@@ -184,20 +184,20 @@ class CombinatorialComplex(ColoredHyperGraph):
         else:
             raise KeyError(f"input {cell} is not in the complex")
 
-    def __contains__(self, item) -> bool:
-        """Return True/False indicating if the item is in self.nodes.
+    def __contains__(self, atom) -> bool:
+        """Check whether this combinatorial complex contains the given atom.
 
         Parameters
         ----------
-        item : hashable or HyperEdge
-            The item to check for existence in the Combinatorial Complex.
+        atom : Any
+            The atom to be checked.
 
         Returns
         -------
         bool
-            True if the item is found in the nodes of the complex, False otherwise.
+            Returns `True` if this combinatorial complex contains the atom, else `False`.
         """
-        return item in self.nodes
+        return atom in self._complex_set
 
     @property
     def __shortstr__(self) -> str:

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -236,18 +236,18 @@ class Complex(abc.ABC):
         """Return an iterator over the nodes."""
 
     @abc.abstractmethod
-    def __contains__(self, item: Any) -> bool:
-        """Check whether the complex contains an item.
+    def __contains__(self, atom: Any) -> bool:
+        """Check whether this complex contains the given atom.
 
         Parameters
         ----------
-        item : Any
-            The item to be checked.
+        atom : Any
+            The atom to be checked.
 
         Returns
         -------
         bool
-            Returns `True` if the complex contains the item else `False`.
+            Returns `True` if the complex contains the atom, else `False`.
         """
 
     @abc.abstractmethod

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -41,7 +41,7 @@ class Atom(abc.ABC, Generic[AtomCollectionType]):
         """
         return len(self.elements)
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self):
         """Return an iterator over the elements in the atom.
 
         Returns
@@ -164,8 +164,14 @@ class Complex(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def nodes(self):
-        """Return the node container."""
+    def nodes(self) -> Iterator[Hashable]:
+        """Return an iterator over the nodes in the complex.
+
+        Returns
+        -------
+        Iterator[Hashable]
+            Iterator over the nodes in the complex.
+        """
 
     @property
     @abc.abstractmethod
@@ -233,7 +239,13 @@ class Complex(abc.ABC):
 
     @abc.abstractmethod
     def __iter__(self) -> Iterator:
-        """Return an iterator over the nodes."""
+        """Return an iterator over the atoms in this complex.
+
+        Returns
+        -------
+        Iterator[Atom]
+            Iterator over the atoms in the complex.
+        """
 
     @abc.abstractmethod
     def __contains__(self, atom: Any) -> bool:

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -263,18 +263,26 @@ class Complex(abc.ABC):
         """
 
     @abc.abstractmethod
-    def __getitem__(self, key):
-        """Get item.
+    def __getitem__(self, atom: Any) -> dict[Hashable, Any]:
+        """Return the user-defined attributes associated with the given atom.
+
+        Writing to the returned dictionary will update the user-defined attributes
+        associated with the atom.
 
         Parameters
         ----------
-        key : hashable
-            Get item based on key.
+        atom : Any
+            The atom for which to return the associated user-defined attributes.
 
         Returns
         -------
-        Hashable
-            The hashable item that needs to be returned.
+        dict[Hashable, Any]
+            The user-defined attributes associated with the given atom.
+
+        Raises
+        ------
+        KeyError
+            If the atom does not exist in this complex.
         """
 
     @abc.abstractmethod

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -347,7 +347,7 @@ class PathComplex(Complex):
                 tmp, key=lambda x: tuple(map(str, x))
             )  # lexicographic comparison
         if rank < 0:
-            raise ValueError(f"input must be a postive integer, got {rank}")
+            raise ValueError(f"input must be a positive integer, got {rank}")
         raise ValueError(f"input {rank} exceeds max dim")
 
     def add_node(self, node: Hashable | Path, **attr) -> None:
@@ -422,7 +422,7 @@ class PathComplex(Complex):
             raise ValueError(f"input dimension d must be positive integer, got {rank}")
         if rank > self.dim:
             raise ValueError(
-                f"input dimenion cannat be larger than the dimension of the complex, got {rank}"
+                f"input dimension cannot be larger than the dimension of the complex, got {rank}"
             )
         if rank == 0:
             boundary = sp.sparse.lil_matrix((0, len(self.nodes)))
@@ -1093,20 +1093,20 @@ class PathComplex(Complex):
             elif len(path_) == 2:
                 self._G.add_edge(path_[0], path_[1], **attr)
 
-    def __contains__(self, item: Sequence[Hashable] | Hashable) -> bool:
-        """Return boolean indicating if item is in self._path_set.
+    def __contains__(self, atom: Any) -> bool:
+        """Check if an atom is in the path complex.
 
         Parameters
         ----------
-        item : Sequence[Hashable] | Hashable
-            The item to check for.
+        atom : Any
+            The atom to check for existence in the path complex.
 
         Returns
         -------
         bool
-            `True` if item is contained else `False`.
+            `True` if the given atom is in the path complex, `False` otherwise.
         """
-        return item in self._path_set
+        return atom in self._path_set
 
     def __getitem__(self, item: Sequence[Hashable] | Hashable):
         """Get the elementary p-path.
@@ -1121,7 +1121,7 @@ class PathComplex(Complex):
         PathView
             The pathview based on the item provided.
         """
-        if item in self:
+        if item in self.paths:
             return self._path_set[item]
         raise KeyError("The elementary p-path is not in the path complex")
 

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -1108,22 +1108,25 @@ class PathComplex(Complex):
         """
         return atom in self._path_set
 
-    def __getitem__(self, item: Sequence[Hashable] | Hashable):
+    def __getitem__(self, atom: Any) -> dict[Hashable, Any]:
         """Get the elementary p-path.
 
         Parameters
         ----------
-        item : Sequence[Hashable] | Hashable
+        atom : Any
             An elementary p-path or a node in the path complex.
 
         Returns
         -------
         PathView
             The pathview based on the item provided.
+
+        Raises
+        ------
+        KeyError
+            If the path does not exist in this path complex.
         """
-        if item in self.paths:
-            return self._path_set[item]
-        raise KeyError("The elementary p-path is not in the path complex")
+        return self._path_set[atom]
 
     def __iter__(self) -> Iterator:
         """Iterate over all faces of the path complex.

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -1133,7 +1133,7 @@ class PathComplex(Complex):
         Iterator
             Iterator for iterating over all faces of the path complex.
         """
-        return iter(self.nodes)
+        return iter(self._path_set)
 
     def __len__(self) -> int:
         """Return the number of elementary p-paths in the path complex.

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -354,38 +354,39 @@ class ColoredHyperEdgeView(AtomView):
         -----
         Assumption of input here hyperedge = ( elements of hyperedge, key of hyperedge)
         """
-        if len(self.hyperedge_dict) == 0:
+        if isinstance(atom, Hashable) and not isinstance(atom, Iterable):
+            atom = (atom,)
+
+        if not isinstance(atom, Iterable):
             return False
-        if isinstance(atom, Iterable):
-            if len(atom) == 0:
-                return False
-            if len(atom) == 2:
-                if isinstance(atom, HyperEdge):
-                    hyperedge_elements = atom.elements
-                    key = 0
-                elif isinstance(atom[0], Iterable) and isinstance(atom[1], int):
-                    hyperedge_elements_ = atom[0]
-                    if not isinstance(hyperedge_elements_, HyperEdge):
-                        hyperedge_elements, key = atom
-                    else:
-                        _, key = atom
-                        hyperedge_elements = hyperedge_elements_.elements
+
+        if len(atom) == 0:
+            return False
+        if len(atom) == 2:
+            if isinstance(atom, HyperEdge):
+                hyperedge_elements = atom.elements
+                key = 0
+            elif isinstance(atom[0], Iterable) and isinstance(atom[1], int):
+                hyperedge_elements_ = atom[0]
+                if not isinstance(hyperedge_elements_, HyperEdge):
+                    hyperedge_elements, key = atom
                 else:
-                    hyperedge_elements = atom
-                    key = 0
+                    _, key = atom
+                    hyperedge_elements = hyperedge_elements_.elements
             else:
                 hyperedge_elements = atom
                 key = 0
-            all_ranks = self.allranks
         else:
-            return False
+            hyperedge_elements = atom
+            key = 0
+
         if isinstance(hyperedge_elements, Iterable) and not isinstance(
             hyperedge_elements, HyperEdge
         ):
             if len(hyperedge_elements) == 0:
                 return False
 
-            for i in all_ranks:
+            for i in self.allranks:
                 if frozenset(hyperedge_elements) in self.hyperedge_dict[i]:
                     return key in self.hyperedge_dict[i][frozenset(hyperedge_elements)]
             return False
@@ -393,11 +394,11 @@ class ColoredHyperEdgeView(AtomView):
             if len(hyperedge_elements) == 0:
                 return False
 
-            for i in all_ranks:
+            for i in self.allranks:
                 if frozenset(hyperedge_elements.elements) in self.hyperedge_dict[i]:
                     return True
             return False
-        return None
+        return False
 
     def __repr__(self) -> str:
         """Return string representation of hyperedges.

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -288,9 +288,6 @@ class ColoredHyperEdgeView(AtomView):
         if isinstance(atom, Hashable) and not isinstance(atom, Collection):
             atom = (atom,)
 
-        if not isinstance(atom, Collection):
-            raise KeyError(f"Hyperedge {atom} is not in the complex.")
-
         if len(atom) == 0:
             raise KeyError(f"Hyperedge {atom} is not in the complex.")
         if len(atom) == 2:
@@ -383,9 +380,6 @@ class ColoredHyperEdgeView(AtomView):
         """
         if isinstance(atom, Hashable) and not isinstance(atom, Collection):
             atom = (atom,)
-
-        if not isinstance(atom, Collection):
-            return False
 
         if len(atom) == 0:
             return False

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -4,7 +4,7 @@ The class also supports attaching arbitrary attributes and data to cells.
 """
 
 from collections.abc import Collection, Hashable, Iterable, Iterator
-from itertools import chain, combinations
+from itertools import combinations
 from typing import Any
 
 import networkx as nx
@@ -314,15 +314,15 @@ class SimplicialComplex(Complex):
             return self._simplex_set[simplex]
         raise KeyError("simplex is not in the simplicial complex")
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[frozenset[Hashable]]:
         """Iterate over all simplices (faces) of the simplicial complex.
 
         Returns
         -------
-        Iterator[Tuple[int, ...]]
+        Iterator[frozenset[Hashable]]
             An iterator over all simplices in the simplicial complex.
         """
-        return chain.from_iterable(self.nodes)
+        return iter(self.simplices)
 
     def __contains__(self, atom: Any) -> bool:
         """Check whether this simplicial complex contains the given atom.

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -292,17 +292,17 @@ class SimplicialComplex(Complex):
         """
         return len(self.skeleton(0))
 
-    def __getitem__(self, simplex) -> dict[Hashable, Any]:
+    def __getitem__(self, atom: Any) -> dict[Hashable, Any]:
         """Get the data associated with the given simplex.
 
         Parameters
         ----------
-        simplex : tuple[int, ...]
+        atom : Any
             The simplex to retrieve.
 
         Returns
         -------
-        Any
+        dict[Hashable, Any]
             The data associated with the given simplex.
 
         Raises
@@ -310,9 +310,7 @@ class SimplicialComplex(Complex):
         KeyError
             If the simplex is not present in the simplicial complex.
         """
-        if simplex in self.simplices:
-            return self._simplex_set[simplex]
-        raise KeyError("simplex is not in the simplicial complex")
+        return self._simplex_set[atom]
 
     def __iter__(self) -> Iterator[frozenset[Hashable]]:
         """Iterate over all simplices (faces) of the simplicial complex.

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -221,7 +221,7 @@ class SimplicialComplex(Complex):
         >>> SC.is_maximal([1, 2])
         False
         """
-        if simplex not in self:
+        if simplex not in self.simplices:
             raise ValueError(f"Simplex {simplex} is not in the simplicial complex.")
         return self[simplex]["is_maximal"]
 
@@ -310,7 +310,7 @@ class SimplicialComplex(Complex):
         KeyError
             If the simplex is not present in the simplicial complex.
         """
-        if simplex in self:
+        if simplex in self.simplices:
             return self._simplex_set[simplex]
         raise KeyError("simplex is not in the simplicial complex")
 
@@ -324,20 +324,20 @@ class SimplicialComplex(Complex):
         """
         return chain.from_iterable(self.nodes)
 
-    def __contains__(self, item) -> bool:
-        """Check if a simplex is in the simplicial complex.
+    def __contains__(self, atom: Any) -> bool:
+        """Check whether this simplicial complex contains the given atom.
 
         Parameters
         ----------
-        item : tuple or list
-            The simplex to check for existence in the simplicial complex.
+        atom : Any
+            The atom to be checked.
 
         Returns
         -------
         bool
-            True if the given simplex is in the simplicial complex, False otherwise.
+            Returns `True` if this simplicial complex contains the atom, else `False`.
         """
-        return item in self._simplex_set
+        return atom in self._simplex_set
 
     def _update_faces_dict_length(self, simplex) -> None:
         """Update the faces dictionary length based on the input simplex.
@@ -582,7 +582,7 @@ class SimplicialComplex(Complex):
             )
 
         # if the simplex is already part of this complex, update its attributes
-        if elements in self:
+        if elements in self.simplices:
             self._simplex_set.faces_dict[len(elements) - 1][elements].update(kwargs)
             return
 
@@ -704,11 +704,11 @@ class SimplicialComplex(Complex):
         if name is not None:
             # if `values` is a dict using `.items()` => {simplex: value}
             for simplex, value in values.items():
-                if simplex in self:
+                if simplex in self.simplices:
                     self[simplex][name] = value
         else:
             for simplex, d in values.items():
-                if simplex in self:
+                if simplex in self.simplices:
                     self[simplex].update(d)
 
     def get_node_attributes(self, name: str) -> dict[Hashable, Any]:
@@ -1339,7 +1339,7 @@ class SimplicialComplex(Complex):
         >>> SC1.simplices
         SimplexView([(1,), (2,), (3,), (4,), (1, 2), (1, 3), (2, 3), (2, 4), (1, 2, 3)])
         """
-        rns = [cell for cell in cell_set if cell in self]
+        rns = [cell for cell in cell_set if cell in self.simplices]
         return self.__class__(simplices=rns)
 
     def restrict_to_nodes(self, node_set):


### PR DESCRIPTION
With this pull request, the dunder methods `__contains__`, `__iter__` and `__getitem__` work consistently across all complex types now:

- `atom in complex` works for any atom now. Previously, depending on the complex class, this was only possible for nodes. Closes #273.
- Iterating over a complex now yields all atoms, not just the nodes. This was previously changed to only iterate over nodes (see #266), but changed now for consistency with other dunder methods. Iterating over the nodes is always possible via the `complex.nodes` property.
- `complex[atom]` is implemented consistently to return the user-defined attributes for that atom. Previously, depending on the complex class, this returned the neighbours of the atom. There are other means to access the neighbours, which may also take into account different notions of neighbourhood. Closes #270.