### PR TITLE
Test against Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  pytest:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         flavor: ["dev", "all"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ all = [
     "TopoNetX[doc, dev]",
 
     # optional packages that are not required to run the library
-    "gudhi",
+    "gudhi >= 3.9.0",
     "hypernetx < 2.0.0",
     "spharapy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ all = [
     "TopoNetX[doc, dev]",
 
     # optional packages that are not required to run the library
-    "gudhi >= 3.9.0",
     "hypernetx < 2.0.0",
     "spharapy"
 ]

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -1,5 +1,7 @@
 """Test simplicial complex class."""
 
+from unittest.mock import Mock
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -9,11 +11,6 @@ from toponetx.classes.combinatorial_complex import CombinatorialComplex
 from toponetx.classes.simplex import Simplex
 from toponetx.classes.simplicial_complex import SimplicialComplex
 from toponetx.datasets.mesh import stanford_bunny
-
-try:
-    from gudhi import SimplexTree
-except ImportError:
-    SimplexTree = None
 
 try:
     import hypernetx as hnx
@@ -819,13 +816,31 @@ class TestSimplicialComplex:
         assert len(result.cells) == len(expected_result.cells)
         assert len(result.nodes) == len(expected_result.nodes)
 
-    @pytest.mark.skipif(
-        SimplexTree is None, reason="Optional dependency 'gudhi' not installed."
-    )
     def test_from_gudhi(self):
         """Create a SimplicialComplex from a Gudhi SimplexTree and compare the number of simplices."""
-        tree = SimplexTree()
-        tree.insert([1, 2, 3, 5])
+        gudhi_simplices = [
+            ([1, 2, 3, 5], 0.0),
+            ([1, 2, 3], 0.0),
+            ([1, 2, 5], 0.0),
+            ([1, 2], 0.0),
+            ([1, 3, 5], 0.0),
+            ([1, 3], 0.0),
+            ([1, 5], 0.0),
+            ([1], 0.0),
+            ([2, 3, 5], 0.0),
+            ([2, 3], 0.0),
+            ([2, 5], 0.0),
+            ([2], 0.0),
+            ([3, 5], 0.0),
+            ([3], 0.0),
+            ([5], 0.0),
+        ]
+        tree = Mock(["get_skeleton", "dimension"])
+        tree.get_skeleton.side_effect = lambda i: (
+            s for s in gudhi_simplices if len(s[0]) <= i + 1
+        )
+        tree.dimension.return_value = 3
+
         expected_result = SimplicialComplex()
         expected_result.add_simplex((1, 2, 3, 5))
         result = SimplicialComplex.from_gudhi(tree)


### PR DESCRIPTION
Run our test suite against Python 3.13.

This pull request also mocks the call to gudhi and removes the explicit dependency. Installing Gudhi on Python 3.13 fails on Github Actions. See also #320.

Closes #399.