### PR TITLE
Fix from_spharapy naming in SimplicialComplex

### DIFF
--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -1096,12 +1096,12 @@ class TestSimplicialComplex:
     @pytest.mark.skipif(
         tm is None, reason="Optional dependency 'spharapy' not installed."
     )
-    def test_from_spharpy(self):
-        """Test the from_spharpy method of SimplicialComplex (support for spharpy trimesh)."""
+    def test_from_spharapy(self):
+        """Test the from_spharapy method of SimplicialComplex (support for spharapy trimesh)."""
         mesh = tm.TriMesh(
             [[0, 1, 2]], [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]
         )
-        SC = SimplicialComplex.from_spharpy(mesh)
+        SC = SimplicialComplex.from_spharapy(mesh)
         simplices = SC.simplices
         assert len(simplices) == 7
         assert [0, 1, 2] in simplices

--- a/test/classes/test_simplicial_complex.py
+++ b/test/classes/test_simplicial_complex.py
@@ -1112,6 +1112,26 @@ class TestSimplicialComplex:
         assert [1] in simplices
         assert [2] in simplices
 
+    @pytest.mark.skipif(
+        tm is None, reason="Optional dependency 'spharapy' not installed."
+    )
+    def test_from_spharpy(self):
+        """Test the deprecated from_spharpy method of SimplicialComplex (support for spharapy trimesh)."""
+        mesh = tm.TriMesh(
+            [[0, 1, 2]], [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]
+        )
+        with pytest.deprecated_call():
+            SC = SimplicialComplex.from_spharpy(mesh)
+        simplices = SC.simplices
+        assert len(simplices) == 7
+        assert [0, 1, 2] in simplices
+        assert [0, 1] in simplices
+        assert [0, 2] in simplices
+        assert [1, 2] in simplices
+        assert [0] in simplices
+        assert [1] in simplices
+        assert [2] in simplices
+
     def test_graph_skeleton(self):
         """Test the graph_skeleton method of SimplicialComplex."""
         SC = SimplicialComplex(

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -1401,7 +1401,7 @@ class SimplicialComplex(Complex):
         return [tuple(s) for s in self.simplices if self.is_maximal(s)]
 
     @classmethod
-    def from_spharpy(cls, mesh) -> Self:
+    def from_spharapy(cls, mesh) -> Self:
         """Import from sharpy.
 
         Parameters
@@ -1423,7 +1423,7 @@ class SimplicialComplex(Complex):
         ...     [[0, 1, 2]], [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]]
         ... )
 
-        >>> SC = tnx.SimplicialComplex.from_spharpy(mesh)
+        >>> SC = tnx.SimplicialComplex.from_spharapy(mesh)
         """
         vertices = np.array(mesh.vertlist)
         SC = cls(mesh.trilist)
@@ -1612,7 +1612,7 @@ class SimplicialComplex(Complex):
         )
 
     def to_spharapy(self, vertex_position_name: str = "position"):
-        """Convert to sharapy.
+        """Convert to spharapy.
 
         Parameters
         ----------
@@ -1635,7 +1635,7 @@ class SimplicialComplex(Complex):
         >>> import spharapy.spharabasis as sb
         >>> import spharapy.datasets as sd
         >>> mesh = tm.TriMesh([[0, 1, 2]], [[0, 0, 0], [0, 0, 1], [0, 1, 0]])
-        >>> SC = tnx.SimplicialComplex.from_spharpy(mesh)
+        >>> SC = tnx.SimplicialComplex.from_spharapy(mesh)
         >>> mesh2 = SC.to_spharapy()
         >>> mesh2.vertlist == mesh.vertlist
         >>> mesh2.trilist == mesh.trilist

--- a/toponetx/classes/simplicial_complex.py
+++ b/toponetx/classes/simplicial_complex.py
@@ -1440,6 +1440,23 @@ class SimplicialComplex(Complex):
 
         return SC
 
+    @classmethod
+    @deprecated("`SimplicialComplex.from_spharpy` is deprecated and will be removed in the future, use `SimplicialComplex.from_spharapy` instead.")
+    def from_spharpy(cls, mesh) -> Self:
+        """Import from sharpy.
+
+        Parameters
+        ----------
+        mesh : spharapy.trimesh.TriMesh
+            The input spharapy object.
+
+        Returns
+        -------
+        SimplicialComplex
+            The resulting SimplicialComplex.
+        """
+        return cls.from_spharapy(mesh)
+
     def to_hasse_graph(self) -> nx.DiGraph:
         """Create the hasse graph corresponding to this simplicial complex.
 


### PR DESCRIPTION
This PR fixes a typo in `SimplicialComplex.from_spharapy` (making it consistent with `SimplicialComplex.to_spharapy` and the library name).