### PR TITLE
Implement `__eq__` for `Atom`s.

### DIFF
--- a/test/classes/test_cell_complex.py
+++ b/test/classes/test_cell_complex.py
@@ -1137,10 +1137,7 @@ class TestCellComplex:
         CC.add_cell([1, 2, 3, 4], rank=2)
         CC.add_cell([1, 2, 3, 4], rank=2)
         CC.add_cell([2, 3, 4, 1], rank=2)
-        CC.add_cell(
-            [1, 2, 4],
-            rank=2,
-        )
+        CC.add_cell([1, 2, 4], rank=2)
         CC.add_cell([3, 4, 8], rank=2)
         assert len(CC.cells) == 5
         CC.remove_equivalent_cells()

--- a/test/classes/test_complex.py
+++ b/test/classes/test_complex.py
@@ -3,6 +3,24 @@
 import pytest
 
 from toponetx.classes.complex import Complex
+from toponetx.classes.hyperedge import HyperEdge
+from toponetx.classes.simplex import Simplex
+
+
+class TestAtom:
+    """Test the Atom class."""
+
+    def test_atoms_equal(self):
+        """Test if two atoms are equal."""
+        h1 = HyperEdge((1, 2))
+        s1 = Simplex((1, 2), weight=1)
+        s2 = Simplex((1, 2), weight=2)
+        s3 = Simplex((1, 2, 3))
+
+        assert s1 == s1
+        assert s1 == s2
+        assert s1 != s3
+        assert s1 != h1
 
 
 class TestComplex:

--- a/toponetx/classes/cell_complex.py
+++ b/toponetx/classes/cell_complex.py
@@ -1329,18 +1329,16 @@ class CellComplex(Complex):
         >>> print(CC.cells)
         >>> CC.remove_equivalent_cells()
         """
+        # delete all cells that are added multiple times
+        for cell in self._cells._cells:
+            if len(self._cells._cells[cell]) > 1:
+                for key in list(self._cells._cells[cell].keys())[1:]:
+                    self._delete_cell(cell, key)
+
         equiv_classes = self._cell_equivalence_class()
         for c in list(self.cells):
             if c not in equiv_classes:
-                d = self._cells._cells[c.elements]
-                if len(d) == 1:
-                    self._delete_cell(c)
-                else:
-                    d_c = dict(d)
-                    for k in d_c:
-                        if len(d) == 1:
-                            break
-                        self._delete_cell(c, k)
+                self._delete_cell(c)
 
     def is_insertable_cycle(
         self,

--- a/toponetx/classes/complex.py
+++ b/toponetx/classes/complex.py
@@ -31,6 +31,44 @@ class Atom(abc.ABC, Generic[AtomCollectionType]):
         self._attributes = {}
         self._attributes.update(kwargs)
 
+    def __eq__(self, other: Any) -> bool:
+        """Return True if the given atom is equal to this atom.
+
+        Atoms are considered equal if they have the same elements but may have
+        different attributes.
+
+        Parameters
+        ----------
+        other : Any
+            The atom to compare.
+
+        Returns
+        -------
+        bool
+            Returns `True` if the given atom is equal to this atom and `False` otherwise.
+
+        Example
+        -------
+        >>> s1 = tnx.Simplex((1, 2), weight=1)
+        >>> s2 = tnx.Simplex((1, 2), weight=2)
+        >>> s3 = tnx.Simplex((1, 2, 3))
+        >>> s1 == s2
+        True
+        >>> s1 == s3
+        False
+        """
+        return type(self) is type(other) and self.elements == other.elements
+
+    def __hash__(self) -> int:
+        """Return the hash of the atom.
+
+        Returns
+        -------
+        int
+            The hash of the atom.
+        """
+        return hash(self.elements)
+
     def __len__(self) -> int:
         """Return the number of elements in the atom.
 

--- a/toponetx/classes/path_complex.py
+++ b/toponetx/classes/path_complex.py
@@ -156,7 +156,7 @@ class PathComplex(Complex):
                         tmp_paths.append(tuple(path))
                     else:  # path is a Path object
                         tmp_paths.append(path)
-            self.add_paths_from(set(tmp_paths))
+            self.add_paths_from(tmp_paths)
         elif paths is not None:
             raise TypeError(
                 "Input paths must be a graph or an iterable of paths as lists or tuples."

--- a/toponetx/classes/reportviews.py
+++ b/toponetx/classes/reportviews.py
@@ -90,11 +90,12 @@ class AtomView(ABC, Generic[T_Atom]):
 class CellView(AtomView[Cell]):
     """A CellView class for cells of a CellComplex."""
 
+    # Dictionary to hold cells, with keys being the tuple that defines the cell, and
+    # values being dictionaries of cell objects with different attributes
+    _cells: dict[tuple[Hashable, ...], dict[int, Cell]]
+
     def __init__(self) -> None:
-        # Initialize a dictionary to hold cells, with keys being the tuple
-        # that defines the cell, and values being dictionaries of cell objects
-        # with different attributes
-        self._cells: dict[tuple[Hashable, ...], dict[int, Cell]] = {}
+        self._cells = {}
 
     def __getitem__(self, cell: Any) -> dict[Hashable, Any]:
         """Return the attributes of a given cell.


### PR DESCRIPTION
Two atoms are considered equal if they have the same elements. User-defined attributes may differ for equal atoms.