### PR TITLE
Switch to `uv`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,19 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Get history and tags for SCM versioning to work
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           git fetch --prune --unshallow
           git tag -d $(git tag --points-at HEAD)
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.x"
-      - name: Install pypa/build
-        run: pip install build --user
-      - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+          enable-cache: true
+
+      - name: Build Wheel
+        run: uv build
+
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
@@ -44,6 +46,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -62,16 +65,19 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Sign the dists with Sigstore
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
+
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -96,6 +102,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,30 +15,29 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.10.11]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - name: Build using Python ${{matrix.python-version}}
-        uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{matrix.python-version}}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
-      - name: Install dependencies [pip]
-        run: |
-          pip install --upgrade pip setuptools wheel
-          pip install -e .[doc]
+          enable-cache: true
+
+      - name: Install Packages
+        run: uv sync --group docs
+
       - name: Install Pandoc [apt-get]
         run: |
           sudo apt-get -y install pandoc
+
+      - name: Document Validation
+        run: uv run numpydoc lint test/**/*.py toponetx/**/*.py
+
       - name: Generate Docs [Sphinx]
-        run: |
-          sphinx-build  -b html -D version=latest -D release=latest docs docs/_build
+        run: uv run sphinx-build -b html -D version=latest -D release=latest docs docs/_build
+
       - name: Deploy Docs
         uses: JamesIves/github-pages-deploy-action@v4
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyt-team/TopoNetX' }}
@@ -49,26 +48,3 @@ jobs:
           repository-name: pyt-team/pyt-team.github.io
           target-folder: toponetx
           clean: true
-
-  numpydoc-validation:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.11.3]
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build using Python ${{matrix.python-version}}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{matrix.python-version}}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
-      - name: Install dependencies [pip]
-        run: |
-          pip install --upgrade pip setuptools wheel
-          pip install -e .[doc]
-      - name: Checking NumpyDoc Validation for files
-        run: |
-          numpydoc lint test/**/*.py toponetx/**/*.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,37 +23,32 @@ concurrency:
 
 jobs:
   pytest:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        flavor: ["dev", "all"]
+        flavor: ["none", "all"]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
+          enable-cache: true
 
       - name: Install Package [${{ matrix.flavor }}]
-        run: |
-          pip install -e .[${{ matrix.flavor }}]
+        run: uv sync --extra ${{ matrix.flavor }}
 
       - name: Typecheck [mypy]
-        run: |
-          mypy -p toponetx
+        run: uv run mypy -p toponetx
         continue-on-error: true
 
       - name: Run tests [pytest]
-        run: |
-          pytest --cov --cov-report=xml:coverage.xml
+        run: uv run pytest --cov --cov-report=xml:coverage.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -41,24 +42,21 @@ dependencies=[
 ]
 
 [project.optional-dependencies]
-doc = [
-    "jupyter",
-    "nbsphinx",
-    "nbsphinx_link",
-    "numpydoc >= 1.8.0",
-    "sphinx",
-    "sphinx-copybutton",
-    "sphinx_gallery",
-    "pydata-sphinx-theme"
+all = [
+    "hypernetx ~= 2.3",
+    "spharapy"
 ]
-lint = [
-    "pre-commit"
-]
-test = [
+
+[project.urls]
+documentation="https://pyt-team.github.io/toponetx/"
+source="https://github.com/pyt-team/TopoNetX/"
+
+[dependency-groups]
+dev = [
+    "pre-commit",
     "pytest",
     "pytest-cov",
     "pytest-xdist",
-    "coverage",
     "jupyter",
 
     # mypy and typing stubs
@@ -67,18 +65,15 @@ test = [
     "types-requests"
 ]
 
-dev = ["TopoNetX[test, lint]"]
-all = [
-    "TopoNetX[doc, dev]",
-
-    # optional packages that are not required to run the library
-    "hypernetx ~=2.3",
-    "spharapy"
+docs = [
+    "nbsphinx",
+    "nbsphinx_link",
+    "numpydoc >= 1.8.0",
+    "sphinx",
+    "sphinx-copybutton",
+    "sphinx_gallery",
+    "pydata-sphinx-theme"
 ]
-
-[project.urls]
-documentation="https://pyt-team.github.io/toponetx/"
-source="https://github.com/pyt-team/TopoNetX/"
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
With this commit, dependencies are managed using [`uv`](https://github.com/astral-sh/uv).

Closes #402.