### PR TITLE
Exclude Python 3.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">= 3.12"
+requires-python = ">=3.12,!=3.14.1"
 dependencies=[
     "more-itertools>=10.7.0",
     "networkx",


### PR DESCRIPTION
Python 3.14.1 has a regression that throws an error inside dataclasses, see python/cpython#142214